### PR TITLE
Exponential cooldown

### DIFF
--- a/cooldown/exponential_cooldown.go
+++ b/cooldown/exponential_cooldown.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type ExponentialCooldown struct {
+	initialDelay time.Duration
+	maxDelay     time.Duration
+	mu           *sync.Mutex
+
+	// mutable:
+
+	lastHit      time.Time
+	currentDelay time.Duration
+}
+
+func NewExponentialCooldown(
+	initialDelay time.Duration,
+	maxDelay time.Duration,
+) *ExponentialCooldown {
+	if initialDelay < time.Nanosecond {
+		panic("expected initialDelay to be positive")
+	}
+	if maxDelay < initialDelay {
+		panic("expected maxDelay to be greater or equal to initialDelay")
+	}
+
+	return &ExponentialCooldown{
+		initialDelay: initialDelay,
+		maxDelay:     maxDelay,
+		mu:           &sync.Mutex{},
+
+		currentDelay: initialDelay,
+	}
+}
+
+// If not in cooldown, returns immediately, and starts the cooldown.
+// If in cooldown, waits until cooled and returns nil. Next delay will be
+// doubled, but always shorter then maxDelay and longer then initialDelay.
+func (cd *ExponentialCooldown) Hit(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	cd.mu.Lock()
+	defer cd.mu.Unlock()
+
+	// repeating cancelation check, since lock may have taken a long time
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	sinceLastHit := time.Since(cd.lastHit)
+
+	if sinceLastHit >= cd.currentDelay {
+		// cooldown has passed by itself - resetting the delay
+		cd.lastHit = time.Now()
+		cd.currentDelay = cd.initialDelay
+		return nil
+	}
+
+	// inside a cooldown
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(cd.currentDelay - sinceLastHit):
+		// cooldown has passed just now - doubling the delay
+		cd.lastHit = time.Now()
+		cd.currentDelay = min(cd.currentDelay*2, cd.maxDelay)
+		return nil
+	}
+}

--- a/cooldown/exponential_cooldown_test.go
+++ b/cooldown/exponential_cooldown_test.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestExponentialCooldown_Hit_DelayGrows(t *testing.T) {
+	cd := NewExponentialCooldown(100*time.Millisecond, time.Second)
+
+	var lastDelay time.Duration
+	for range 5 {
+		start := time.Now()
+		if err := cd.Hit(context.Background()); err != nil {
+			t.Errorf("expected nil err, got %v", err)
+		}
+		delay := time.Since(start)
+		if delay <= lastDelay {
+			t.Errorf(
+				"expected delay to grow after each hit, got %v->%v",
+				lastDelay, delay,
+			)
+		}
+		lastDelay = delay
+	}
+}


### PR DESCRIPTION
Primitive to be used in scenarios, when we need the backend to be "cooled" before next use.

See tests and docs for details