### PR TITLE
Cooldown Batcher

### DIFF
--- a/cooldown/batcher.go
+++ b/cooldown/batcher.go
@@ -49,6 +49,7 @@ func (b *Batcher) Add(newItem any) error {
 	return nil
 }
 
+// See [Batcher]
 func (b *Batcher) ConsumeWithCooldown(
 	ctx context.Context,
 	cooldown Cooldown,

--- a/cooldown/batcher.go
+++ b/cooldown/batcher.go
@@ -8,6 +8,9 @@ import (
 
 type BatchAppend func(batch []any, newItem any) []any
 
+// Buffer, which is populated via [Batcher.Add] and consumed with
+// [Batcher.ConsumeWithCooldown]. Allows batching items (see batchAppend in
+// [NewBatcher]) and consuming them in time-controlled way - with cooldown.
 type Batcher struct {
 	mu          *sync.Mutex
 	cond        *sync.Cond
@@ -15,6 +18,8 @@ type Batcher struct {
 	items       []any
 }
 
+// Creates new [*Batcher] with batchAppend, which allows modifying current batch
+// buffer before consumer takes it.
 func NewBatcher(batchAppend BatchAppend) *Batcher {
 	if batchAppend == nil {
 		batchAppend = func(batch []any, newItem any) []any {

--- a/cooldown/batcher.go
+++ b/cooldown/batcher.go
@@ -1,0 +1,121 @@
+package cooldown
+
+import (
+	"context"
+	"iter"
+	"sync"
+)
+
+type BatchAppend func(batch []any, newItem any) []any
+
+type Batcher struct {
+	mu          *sync.Mutex
+	cond        *sync.Cond
+	batchAppend BatchAppend
+	items       []any
+}
+
+func NewBatcher(batchAppend BatchAppend) *Batcher {
+	if batchAppend == nil {
+		batchAppend = func(batch []any, newItem any) []any {
+			return append(batch, newItem)
+		}
+	}
+
+	mu := &sync.Mutex{}
+	return &Batcher{
+		mu:          mu,
+		cond:        sync.NewCond(mu),
+		batchAppend: batchAppend,
+	}
+}
+
+func (b *Batcher) Add(newItem any) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.items = b.batchAppend(b.items, newItem)
+
+	// let the appender to cancel out the current batch
+	if len(b.items) > 0 {
+		b.cond.Signal()
+	}
+
+	return nil
+}
+
+func (b *Batcher) ConsumeWithCooldown(
+	ctx context.Context,
+	cooldown Cooldown,
+) iter.Seq[[]any] {
+	return func(yield func([]any) bool) {
+		for {
+			items, err := b.waitForItem(ctx)
+
+			if err != nil {
+				// context cancelation, ok to drop items
+				return
+			}
+
+			if cooldown != nil {
+				if err := cooldown.Hit(ctx); err != nil {
+					// context cancelation, ok to drop items
+					return
+				}
+			}
+
+			if !yield(items) {
+				return
+			}
+		}
+	}
+}
+
+func (b *Batcher) waitForItem(ctx context.Context) ([]any, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// it has already been triggered, while we were not waiting
+	if len(b.items) > 0 {
+		return b.takeBatch(), nil
+	}
+
+	// awakener is a goroutine, which will call "fake" Signal in order to stop
+	// Wait() on context cancelation
+	awakenerDone := make(chan struct{})
+	defer func() {
+		<-awakenerDone
+	}()
+
+	awakenerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		<-awakenerCtx.Done()
+		b.cond.Signal()
+		awakenerDone <- struct{}{}
+	}()
+
+	b.cond.Wait()
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	return b.takeBatch(), nil
+}
+
+func (b *Batcher) takeBatch() []any {
+	res := make([]any, len(b.items))
+	copy(res, b.items)
+
+	// free elements, but keep the array, which is managed by batchAppend
+	clear(b.items)
+	b.items = b.items[:0]
+
+	return res
+}

--- a/cooldown/batcher_test.go
+++ b/cooldown/batcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"iter"
 	"testing"
+	"time"
 )
 
 func TestBatcher_NoCooldown(t *testing.T) {
@@ -40,5 +41,69 @@ func TestBatcher_NoCooldown(t *testing.T) {
 		if batch[i].(int) != i {
 			t.Fatalf("expected items in order, expected %d got %d", i, batch[i].(int))
 		}
+	}
+}
+
+func TestBatcher_WithCooldown(t *testing.T) {
+	cdDelay := 100 * time.Millisecond
+	timeout := 550 * time.Millisecond
+	timeDelta := 10 * time.Millisecond
+
+	batcher := NewBatcher(
+		// do not collect items, but always keep one
+		func(batch []any, newItem any) []any {
+			if len(batch) == 1 {
+				return batch
+			}
+			return []any{true}
+		},
+	)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// adder
+	adderDone := make(chan struct{})
+	go func() {
+		for ctx.Err() == nil {
+			batcher.Add(true)
+			time.Sleep(time.Microsecond)
+		}
+		adderDone <- struct{}{}
+	}()
+
+	cooldown := NewExponentialCooldown(cdDelay, cdDelay)
+
+	lastMoment := time.Now()
+	var delays []time.Duration
+	for range batcher.ConsumeWithCooldown(ctx, cooldown) {
+		delays = append(delays, time.Since(lastMoment))
+
+		lastMoment = time.Now()
+	}
+
+	delays = append(delays, time.Since(lastMoment))
+
+	// assert
+	assertDurationApproximatelyEqual(t, delays[0], 0, timeDelta)
+
+	for i := 1; i < 5; i++ {
+		assertDurationApproximatelyEqual(t, delays[i], cdDelay, timeDelta)
+	}
+
+	assertDurationApproximatelyEqual(t, delays[6], cdDelay/2, timeDelta)
+
+	<-adderDone
+}
+
+func assertDurationApproximatelyEqual(
+	t *testing.T,
+	actual time.Duration,
+	expected time.Duration,
+	delta time.Duration,
+) {
+	diff := (expected - actual).Abs()
+	delta = delta.Abs()
+	if diff > delta {
+		t.Errorf("expected duration to equal %v ± %v, got %v", expected, delta, actual)
 	}
 }

--- a/cooldown/batcher_test.go
+++ b/cooldown/batcher_test.go
@@ -1,0 +1,44 @@
+package cooldown
+
+import (
+	"context"
+	"iter"
+	"testing"
+)
+
+func TestBatcher_NoCooldown(t *testing.T) {
+	batchSize := 100
+
+	batcher := NewBatcher(nil)
+
+	for i := range batchSize {
+		batcher.Add(i)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	next, stop := iter.Pull(batcher.ConsumeWithCooldown(ctx, nil))
+	defer stop()
+
+	batch, ok := next()
+	if !ok {
+		t.Fatal("expected a batch, got nothing")
+	}
+
+	cancel()
+	_, ok2 := next()
+	if ok2 {
+		t.Fatal("expected one batch, got many")
+	}
+
+	if len(batch) != batchSize {
+		t.Fatalf("expected batch of size %d, got %d", batchSize, len(batch))
+	}
+
+	for i := range batch {
+		if batch[i].(int) != i {
+			t.Fatalf("expected items in order, expected %d got %d", i, batch[i].(int))
+		}
+	}
+}

--- a/cooldown/cooldown.go
+++ b/cooldown/cooldown.go
@@ -1,0 +1,13 @@
+package cooldown
+
+import "context"
+
+// Represents a resource, which should not be used too frequently and needs
+// "cooling" before next usage.
+type Cooldown interface {
+	// If not in cooldown, returns immediately, and starts the cooldown.
+	// If in cooldown, waits until cooled and returns nil. Next delay will be
+	// doubled, but not longer then maxDelay.
+	// The only possible error is ctx.Err().
+	Hit(ctx context.Context) error
+}

--- a/cooldown/exponential_cooldown.go
+++ b/cooldown/exponential_cooldown.go
@@ -36,9 +36,7 @@ func NewExponentialCooldown(
 	}
 }
 
-// If not in cooldown, returns immediately, and starts the cooldown.
-// If in cooldown, waits until cooled and returns nil. Next delay will be
-// doubled, but always shorter then maxDelay and longer then initialDelay.
+// Implements [Cooldown]
 func (cd *ExponentialCooldown) Hit(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err


### PR DESCRIPTION
`cooldown.Batcher` allows slowly consuming items in batches. It is helpful for consuming from verbose sources, when you need to act on a backend, which needs to be "cooled down"

See tests and docs for details.