### PR TITLE
Fix OwnLogger panic when opts nil

### DIFF
--- a/slogh/README.md
+++ b/slogh/README.md
@@ -72,6 +72,8 @@ stringValues=true
 
 Alternative configuration file location can be provided directly with `slogh.ConfigFileWatcherOptions` (higher priority), or with env var `SLOGH_CONFIG_PATH` (lower priority).
 
+In Kubernetes, you can map `ConfigMap` into a config file in your container, and it will be reloaded automatically without container restart. See [instruction](https://kubernetes.io/docs/concepts/storage/volumes/#configmap).
+
 ## Token rendering in messages
 
 Option `render=true` or `slogh.Config{Render: slogh.RenderEnabled}` allows to render attribute values directly to your messages, using single-quoted attribute names as tokens.

--- a/slogh/file_watcher.go
+++ b/slogh/file_watcher.go
@@ -71,9 +71,10 @@ func RunConfigFileWatcher(
 
 	// own logger
 	if opts != nil {
-		if log = opts.OwnLogger; log == nil {
-			log = slog.Default()
-		}
+		log = opts.OwnLogger
+	}
+	if log == nil {
+		log = slog.Default()
 	}
 
 	// polling loop, which should normally be replaced with loop in [watchConfig]


### PR DESCRIPTION
When `opts==nil`, `log` won't be initialized with `slog.Default()`, which leads to a panic inside `RunConfigFileWatcher`.