### PR TITLE
feat: add WithFileAtPath method to fake filesystem builder

### DIFF
--- a/fs/fake/builder.go
+++ b/fs/fake/builder.go
@@ -61,13 +61,14 @@ func (b *Builder) WithFile(path string, args ...any) *Builder {
 // instead of nested fake.NewFile() calls.
 //
 // Example:
-//   builder.WithFileAtPath("sys/block/dm-1/dm/name", fake.RWContentFromString("ubuntu--vg-ubuntu--lv"))
-//   builder.WithFileAtPath("dev/mapper/ubuntu--vg-ubuntu--lv", fake.NewFile("ubuntu--vg-ubuntu--lv"))
+//
+//	builder.WithFileAtPath("sys/block/dm-1/dm/name", fake.RWContentFromString("ubuntu--vg-ubuntu--lv"))
+//	builder.WithFileAtPath("dev/mapper/ubuntu--vg-ubuntu--lv", fake.NewFile("ubuntu--vg-ubuntu--lv"))
 func (b *Builder) WithFileAtPath(path string, args ...any) *Builder {
 	if b.OS != nil {
 		// Extract directory path
 		dirPath := filepath.Dir(path)
-		
+
 		// Skip if we're creating a file in the root directory
 		if dirPath != "." && dirPath != "/" {
 			// Create parent directories recursively
@@ -76,7 +77,7 @@ func (b *Builder) WithFileAtPath(path string, args ...any) *Builder {
 				return b
 			}
 		}
-		
+
 		// Create the file
 		if _, err := b.CreateEntry(path, args...); err != nil {
 			b.err = errors.Join(b.err, err)

--- a/fs/fake/builder.go
+++ b/fs/fake/builder.go
@@ -56,6 +56,35 @@ func (b *Builder) WithFile(path string, args ...any) *Builder {
 	return b
 }
 
+// WithFileAtPath creates a file at the given path, automatically creating parent directories
+// This is a convenience method that allows creating files with standard path syntax
+// instead of nested fake.NewFile() calls.
+//
+// Example:
+//   builder.WithFileAtPath("sys/block/dm-1/dm/name", fake.RWContentFromString("ubuntu--vg-ubuntu--lv"))
+//   builder.WithFileAtPath("dev/mapper/ubuntu--vg-ubuntu--lv", fake.NewFile("ubuntu--vg-ubuntu--lv"))
+func (b *Builder) WithFileAtPath(path string, args ...any) *Builder {
+	if b.OS != nil {
+		// Extract directory path
+		dirPath := filepath.Dir(path)
+		
+		// Skip if we're creating a file in the root directory
+		if dirPath != "." && dirPath != "/" {
+			// Create parent directories recursively
+			if err := b.OS.MkdirAll(dirPath, 0755); err != nil {
+				b.err = errors.Join(b.err, err)
+				return b
+			}
+		}
+		
+		// Create the file
+		if _, err := b.CreateEntry(path, args...); err != nil {
+			b.err = errors.Join(b.err, err)
+		}
+	}
+	return b
+}
+
 func (b *Builder) Build() (os *OS, err error) {
 	b.OS, os = os, b.OS
 	b.err, err = err, b.err

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/deckhouse/sds-common-lib
 
-go 1.24.5
+go 1.24.4
 
 toolchain go1.24.6
 


### PR DESCRIPTION
- Add WithFileAtPath method that creates files at nested paths automatically
- Automatically creates parent directories using MkdirAll
- Provides more intuitive API compared to nested fake.NewFile() calls
- Add comprehensive tests covering various scenarios
- Maintains backward compatibility with existing WithFile method
- Changed minimal go version to 1.24.4 to match our CI

Example usage:
```go
  builder.WithFileAtPath("sys/block/dm-1/dm/name", fake.RWContentFromString("ubuntu--vg-ubuntu--lv"))
  builder.WithFileAtPath("dev/mapper/ubuntu--vg-ubuntu--lv", fake.NewFile("ubuntu--vg-ubuntu--lv"))
```
## Description
<!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components
  (restarts of ingress-controllers, control-plane, Prometheus, etc).
-->

## Why do we need it, and what problem does it solve?
<!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
-->

## What is the expected result?
<!---
  How can one check these changes after applying?  

  Describe, what (resource, state, event, etc.) MUST or MUST NOT change/happen after applying these changes.
-->

## Checklist
- [x] The code is covered by unit tests.
- [ ] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [ ] Changes were tested in the Kubernetes cluster manually.
