### PR TITLE
IntersectKeys and CollectGrouped utility functions for maps

### DIFF
--- a/utils/maps/maps.go
+++ b/utils/maps/maps.go
@@ -1,5 +1,7 @@
 package maps
 
+import "iter"
+
 // Set sets key to value in the provided map.
 // If the provided map is nil, a new map is created and returned
 // containing the single key-value pair.
@@ -10,5 +12,50 @@ func Set[K comparable, V any](m map[K]V, key K, value V) map[K]V {
 		return map[K]V{key: value}
 	}
 	m[key] = value
+	return m
+}
+
+// IntersectKeys computes the relationship between the keys of two maps.
+// It returns three sets (as maps with empty-struct values):
+//   - onlyLeft: keys present in left but not in right
+//   - both: keys present in both left and right
+//   - onlyRight: keys present in right but not in left
+//
+// The values of the input maps are ignored; only the keys matter.
+func IntersectKeys[K comparable, V any, W any](
+	left map[K]V,
+	right map[K]W,
+) (
+	onlyLeft map[K]struct{},
+	both map[K]struct{},
+	onlyRight map[K]struct{},
+) {
+	onlyLeft = map[K]struct{}{}
+	onlyRight = map[K]struct{}{}
+	both = map[K]struct{}{}
+
+	for k := range left {
+		if _, ok := right[k]; ok {
+			both[k] = struct{}{}
+		} else {
+			onlyLeft[k] = struct{}{}
+		}
+	}
+	for k := range right {
+		if _, ok := both[k]; !ok {
+			onlyRight[k] = struct{}{}
+		}
+	}
+	return
+}
+
+// CollectGrouped consumes a key-value sequence and groups values by key.
+// For each yielded pair (k, v) in seq, it appends v to result[k].
+// The returned map is initialized and contains slices for all observed keys.
+func CollectGrouped[K comparable, V any](seq iter.Seq2[K, V]) map[K][]V {
+	m := make(map[K][]V)
+	for k, v := range seq {
+		m[k] = append(m[k], v)
+	}
 	return m
 }

--- a/utils/maps/maps_test.go
+++ b/utils/maps/maps_test.go
@@ -63,3 +63,134 @@ func TestMapSet(t *testing.T) {
 		}
 	})
 }
+
+func TestIntersectKeys(t *testing.T) {
+	t.Run("disjoint keys", func(t *testing.T) {
+		left := map[string]int{"a": 1, "b": 2}
+		right := map[string]bool{"c": true, "d": false}
+
+		onlyLeft, both, onlyRight := umaps.IntersectKeys(left, right)
+
+		if len(both) != 0 {
+			t.Errorf("expected both to be empty, got %v", both)
+		}
+		if len(onlyLeft) != 2 || len(onlyRight) != 2 {
+			t.Errorf("expected onlyLeft=2 and onlyRight=2, got %d and %d", len(onlyLeft), len(onlyRight))
+		}
+		if _, ok := onlyLeft["a"]; !ok {
+			t.Error("expected 'a' in onlyLeft")
+		}
+		if _, ok := onlyRight["c"]; !ok {
+			t.Error("expected 'c' in onlyRight")
+		}
+	})
+
+	t.Run("partial overlap", func(t *testing.T) {
+		left := map[string]int{"a": 1, "b": 2, "c": 3}
+		right := map[string]struct{}{"b": {}, "d": {}}
+
+		onlyLeft, both, onlyRight := umaps.IntersectKeys(left, right)
+
+		if len(both) != 1 || len(onlyLeft) != 2 || len(onlyRight) != 1 {
+			t.Errorf("expected both=1, onlyLeft=2, onlyRight=1; got %d, %d, %d", len(both), len(onlyLeft), len(onlyRight))
+		}
+		if _, ok := both["b"]; !ok {
+			t.Error("expected 'b' in both")
+		}
+		if _, ok := onlyLeft["a"]; !ok || func() bool { _, ok := onlyLeft["c"]; return ok }() == false {
+			t.Error("expected 'a' and 'c' in onlyLeft")
+		}
+		if _, ok := onlyRight["d"]; !ok {
+			t.Error("expected 'd' in onlyRight")
+		}
+	})
+
+	t.Run("identical keys", func(t *testing.T) {
+		left := map[int]string{1: "x", 2: "y"}
+		right := map[int]float64{1: 1.1, 2: 2.2}
+
+		onlyLeft, both, onlyRight := umaps.IntersectKeys(left, right)
+
+		if len(onlyLeft) != 0 || len(onlyRight) != 0 || len(both) != 2 {
+			t.Errorf("expected onlyLeft=0, onlyRight=0, both=2; got %d, %d, %d", len(onlyLeft), len(onlyRight), len(both))
+		}
+		if _, ok := both[1]; !ok {
+			t.Error("expected key 1 in both")
+		}
+		if _, ok := both[2]; !ok {
+			t.Error("expected key 2 in both")
+		}
+	})
+
+	t.Run("empty maps", func(t *testing.T) {
+		left := map[string]int{}
+		right := map[string]bool{}
+
+		onlyLeft, both, onlyRight := umaps.IntersectKeys(left, right)
+		if len(onlyLeft) != 0 || len(both) != 0 || len(onlyRight) != 0 {
+			t.Errorf("expected all empty; got onlyLeft=%v both=%v onlyRight=%v", onlyLeft, both, onlyRight)
+		}
+	})
+
+	t.Run("nil maps", func(t *testing.T) {
+		var left map[string]int
+		var right map[string]bool
+
+		onlyLeft, both, onlyRight := umaps.IntersectKeys(left, right)
+		// ranging over a nil map is safe and yields nothing; function should return empty sets
+		if len(onlyLeft) != 0 || len(both) != 0 || len(onlyRight) != 0 {
+			t.Errorf("expected all empty for nil inputs; got onlyLeft=%v both=%v onlyRight=%v", onlyLeft, both, onlyRight)
+		}
+	})
+}
+
+func TestCollectGrouped(t *testing.T) {
+	t.Run("groups values by key with multiple entries", func(t *testing.T) {
+		seq := func(yield func(string, int) bool) {
+			if !yield("a", 1) {
+				return
+			}
+			if !yield("b", 10) {
+				return
+			}
+			if !yield("a", 2) {
+				return
+			}
+			if !yield("b", 20) {
+				return
+			}
+			if !yield("a", 3) {
+				return
+			}
+		}
+		got := umaps.CollectGrouped(seq)
+
+		if len(got) != 2 {
+			t.Fatalf("expected 2 keys, got %d", len(got))
+		}
+		wantA := []int{1, 2, 3}
+		wantB := []int{10, 20}
+
+		if len(got["a"]) != len(wantA) || len(got["b"]) != len(wantB) {
+			t.Fatalf("unexpected slice lengths: a=%v b=%v", got["a"], got["b"])
+		}
+		for i, v := range wantA {
+			if got["a"][i] != v {
+				t.Errorf("a[%d]=%d, want %d", i, got["a"][i], v)
+			}
+		}
+		for i, v := range wantB {
+			if got["b"][i] != v {
+				t.Errorf("b[%d]=%d, want %d", i, got["b"][i], v)
+			}
+		}
+	})
+
+	t.Run("empty sequence returns empty map", func(t *testing.T) {
+		seq := func(yield func(string, int) bool) {}
+		got := umaps.CollectGrouped(seq)
+		if len(got) != 0 {
+			t.Errorf("expected empty map, got %v", got)
+		}
+	})
+}


### PR DESCRIPTION
## Description
- `IntersectKeys`
- `CollectGrouped`
- tests (100% coverage)

## Why do we need it, and what problem does it solve?
- both functions would be helpful in several places during reconcile

## What is the expected result?

## Checklist
- [X] The code is covered by unit tests.
- [X] Documentation updated according to the changes.
- [X] Changes were tested in the Kubernetes cluster manually.
