### PR TITLE
feat(conditions): add a shared status conditions package

### DIFF
--- a/conditions/conditions.go
+++ b/conditions/conditions.go
@@ -1,0 +1,148 @@
+// Package conditions provides a single way for storage modules to publish
+// `status.conditions` on their custom resources.
+//
+// It deliberately works on a plain *[]metav1.Condition rather than on a
+// Getter/Setter interface: the CRD status types across the modules are a mix of
+// value and pointer structs, and none of them implement a common interface
+// today. Taking the slice directly keeps the helper usable without touching
+// every API package first.
+//
+// The Kubernetes API conventions this package follows are documented in
+// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
+package conditions
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TypeReady is the aggregate condition every resource is expected to publish:
+//
+//   - True    the controller has fully reconciled the resource;
+//   - False   reconciliation failed or is still in progress;
+//   - Unknown the controller has not observed the resource yet.
+//
+// Resources whose reconciliation has distinguishable stages publish a condition
+// per stage in addition to TypeReady, and derive TypeReady from them with
+// [Aggregate].
+const TypeReady = "Ready"
+
+// Condition reasons shared across modules. Reasons are short, stable,
+// machine-readable CamelCase identifiers; human-readable detail belongs in
+// condition.message, never in the reason.
+//
+// A module may add its own reasons for stage conditions, but should reuse these
+// for TypeReady so that alerts and dashboards can be written once.
+const (
+	// ReasonReconciled is set on Ready=True after a successful reconcile pass.
+	ReasonReconciled = "Reconciled"
+	// ReasonReconcileFailed is set on Ready=False when a reconcile pass
+	// returned an error. The error text goes into condition.message.
+	ReasonReconcileFailed = "ReconcileFailed"
+	// ReasonPending is set on Ready=Unknown before the first reconcile pass
+	// has produced a verdict.
+	ReasonPending = "Pending"
+	// ReasonWaitingForDependency is set on Ready=False when reconciliation
+	// cannot proceed until another resource becomes ready. The dependency is
+	// named in condition.message.
+	ReasonWaitingForDependency = "WaitingForDependency"
+	// ReasonDeleting is set on Ready=False while the resource is being torn
+	// down after a deletion request.
+	ReasonDeleting = "Deleting"
+)
+
+// Set adds or updates cond in conds and reports whether anything changed.
+//
+// LastTransitionTime is preserved when only the reason, message or
+// observedGeneration change, so periodic resyncs do not make it look like the
+// resource keeps flapping. If cond.LastTransitionTime is zero it is filled in
+// with the current time on an actual status transition.
+func Set(conds *[]metav1.Condition, cond metav1.Condition) bool {
+	return meta.SetStatusCondition(conds, cond)
+}
+
+// Remove deletes the condition with the given type and reports whether it was
+// present. Use it when a condition stops being meaningful — for example a stage
+// condition for a leg of reconciliation that the spec no longer enables.
+// Prefer flipping a condition to False over removing it: a missing condition is
+// indistinguishable from "never evaluated".
+func Remove(conds *[]metav1.Condition, conditionType string) bool {
+	return meta.RemoveStatusCondition(conds, conditionType)
+}
+
+// Get returns the condition with the given type, or nil when it is absent.
+func Get(conds []metav1.Condition, conditionType string) *metav1.Condition {
+	return meta.FindStatusCondition(conds, conditionType)
+}
+
+// IsTrue reports whether the condition is present and True.
+//
+// Note that a missing condition yields false, same as an explicit False. Where
+// the difference matters — "not ready" versus "not yet observed" — use [Get] or
+// [IsUnknown] instead.
+func IsTrue(conds []metav1.Condition, conditionType string) bool {
+	return meta.IsStatusConditionTrue(conds, conditionType)
+}
+
+// IsFalse reports whether the condition is present and False.
+func IsFalse(conds []metav1.Condition, conditionType string) bool {
+	return meta.IsStatusConditionFalse(conds, conditionType)
+}
+
+// IsUnknown reports whether the condition is absent, or present and Unknown.
+func IsUnknown(conds []metav1.Condition, conditionType string) bool {
+	c := meta.FindStatusCondition(conds, conditionType)
+	return c == nil || c.Status == metav1.ConditionUnknown
+}
+
+// IsStale reports whether the condition is missing, or was recorded for an
+// older generation than the one currently in metadata.generation.
+//
+// This is the check that distinguishes "the controller says everything is fine"
+// from "the controller has not looked at your latest change yet", which a bare
+// status value cannot express. Callers gating on a dependency should treat a
+// stale condition as not-ready regardless of its status.
+func IsStale(conds []metav1.Condition, conditionType string, generation int64) bool {
+	c := meta.FindStatusCondition(conds, conditionType)
+	return c == nil || c.ObservedGeneration < generation
+}
+
+// SemanticallyEqual compares two conditions ignoring LastTransitionTime.
+//
+// Two nil conditions are equal; a nil and a non-nil condition are not.
+func SemanticallyEqual(a, b *metav1.Condition) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	return a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message &&
+		a.ObservedGeneration == b.ObservedGeneration
+}
+
+// Ready builds the aggregate Ready condition for a reconcile pass that ended
+// with err (nil on success). It is the one-liner behind the uniform behaviour
+// of the single-stage controllers:
+//
+//	cond := conditions.Ready(obj.Generation, err)
+//
+// On failure the error text becomes the message, so err should be wrapped with
+// enough context to be readable in `kubectl describe` — and must not carry
+// secrets, since conditions are world-readable to anyone who can get the
+// resource.
+func Ready(generation int64, err error) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               TypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             ReasonReconciled,
+		ObservedGeneration: generation,
+	}
+	if err != nil {
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = ReasonReconcileFailed
+		cond.Message = err.Error()
+	}
+	return cond
+}

--- a/conditions/conditions_test.go
+++ b/conditions/conditions_test.go
@@ -1,0 +1,197 @@
+package conditions_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/sds-common-lib/conditions"
+)
+
+func TestSet_AddsAndReportsChange(t *testing.T) {
+	var conds []metav1.Condition
+
+	if !conditions.Set(&conds, metav1.Condition{
+		Type:   conditions.TypeReady,
+		Status: metav1.ConditionTrue,
+		Reason: conditions.ReasonReconciled,
+	}) {
+		t.Fatal("expected Set to report a change when adding a condition")
+	}
+	if len(conds) != 1 {
+		t.Fatalf("expected 1 condition, got %d", len(conds))
+	}
+	if conds[0].LastTransitionTime.IsZero() {
+		t.Fatal("expected LastTransitionTime to be filled in")
+	}
+}
+
+func TestSet_PreservesLastTransitionTimeWhenStatusUnchanged(t *testing.T) {
+	earlier := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+	conds := []metav1.Condition{{
+		Type:               conditions.TypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             conditions.ReasonReconciled,
+		LastTransitionTime: earlier,
+	}}
+
+	// Same status, different observedGeneration: this is what a periodic
+	// resync after a spec bump looks like, and it must not read as a flap.
+	conditions.Set(&conds, metav1.Condition{
+		Type:               conditions.TypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             conditions.ReasonReconciled,
+		ObservedGeneration: 7,
+	})
+
+	if !conds[0].LastTransitionTime.Equal(&earlier) {
+		t.Fatalf("expected LastTransitionTime %v to be preserved, got %v", earlier, conds[0].LastTransitionTime)
+	}
+	if conds[0].ObservedGeneration != 7 {
+		t.Fatalf("expected observedGeneration 7, got %d", conds[0].ObservedGeneration)
+	}
+}
+
+func TestSet_BumpsLastTransitionTimeOnStatusChange(t *testing.T) {
+	earlier := metav1.NewTime(time.Now().Add(-time.Hour).Truncate(time.Second))
+	conds := []metav1.Condition{{
+		Type:               conditions.TypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             conditions.ReasonReconciled,
+		LastTransitionTime: earlier,
+	}}
+
+	conditions.Set(&conds, metav1.Condition{
+		Type:   conditions.TypeReady,
+		Status: metav1.ConditionFalse,
+		Reason: conditions.ReasonReconcileFailed,
+	})
+
+	if conds[0].LastTransitionTime.Equal(&earlier) {
+		t.Fatal("expected LastTransitionTime to advance when the status changes")
+	}
+}
+
+func TestGetAndPredicates(t *testing.T) {
+	conds := []metav1.Condition{
+		{Type: "A", Status: metav1.ConditionTrue},
+		{Type: "B", Status: metav1.ConditionFalse},
+		{Type: "C", Status: metav1.ConditionUnknown},
+	}
+
+	if got := conditions.Get(conds, "A"); got == nil || got.Status != metav1.ConditionTrue {
+		t.Fatalf("expected to find A=True, got %v", got)
+	}
+	if conditions.Get(conds, "missing") != nil {
+		t.Fatal("expected nil for an absent condition")
+	}
+
+	for _, tc := range []struct {
+		name              string
+		fn                func([]metav1.Condition, string) bool
+		wantA, wantB      bool
+		wantC, wantAbsent bool
+	}{
+		{"IsTrue", conditions.IsTrue, true, false, false, false},
+		{"IsFalse", conditions.IsFalse, false, true, false, false},
+		{"IsUnknown", conditions.IsUnknown, false, false, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.fn(conds, "A"); got != tc.wantA {
+				t.Errorf("A: got %v, want %v", got, tc.wantA)
+			}
+			if got := tc.fn(conds, "B"); got != tc.wantB {
+				t.Errorf("B: got %v, want %v", got, tc.wantB)
+			}
+			if got := tc.fn(conds, "C"); got != tc.wantC {
+				t.Errorf("C: got %v, want %v", got, tc.wantC)
+			}
+			if got := tc.fn(conds, "missing"); got != tc.wantAbsent {
+				t.Errorf("missing: got %v, want %v", got, tc.wantAbsent)
+			}
+		})
+	}
+}
+
+func TestIsStale(t *testing.T) {
+	conds := []metav1.Condition{{
+		Type:               conditions.TypeReady,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: 3,
+	}}
+
+	if conditions.IsStale(conds, conditions.TypeReady, 3) {
+		t.Error("condition recorded for the current generation must not be stale")
+	}
+	// Ready=True, but recorded before the user's latest spec change: the
+	// controller has not seen generation 4 yet.
+	if !conditions.IsStale(conds, conditions.TypeReady, 4) {
+		t.Error("condition recorded for an older generation must be stale")
+	}
+	if !conditions.IsStale(conds, "missing", 1) {
+		t.Error("an absent condition must be stale")
+	}
+}
+
+func TestSemanticallyEqual(t *testing.T) {
+	base := metav1.Condition{
+		Type:               conditions.TypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             conditions.ReasonReconciled,
+		Message:            "ok",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+
+	sameButLater := base
+	sameButLater.LastTransitionTime = metav1.NewTime(time.Now().Add(time.Hour))
+	if !conditions.SemanticallyEqual(&base, &sameButLater) {
+		t.Error("LastTransitionTime must not affect semantic equality")
+	}
+
+	differentGen := base
+	differentGen.ObservedGeneration = 2
+	if conditions.SemanticallyEqual(&base, &differentGen) {
+		t.Error("observedGeneration must affect semantic equality")
+	}
+
+	if !conditions.SemanticallyEqual(nil, nil) {
+		t.Error("two nil conditions are equal")
+	}
+	if conditions.SemanticallyEqual(&base, nil) {
+		t.Error("nil and non-nil conditions are not equal")
+	}
+}
+
+func TestReady(t *testing.T) {
+	ok := conditions.Ready(5, nil)
+	if ok.Status != metav1.ConditionTrue ||
+		ok.Reason != conditions.ReasonReconciled ||
+		ok.ObservedGeneration != 5 ||
+		ok.Message != "" {
+		t.Fatalf("unexpected success condition: %+v", ok)
+	}
+
+	failed := conditions.Ready(5, errors.New("boom"))
+	if failed.Status != metav1.ConditionFalse ||
+		failed.Reason != conditions.ReasonReconcileFailed ||
+		failed.Message != "boom" {
+		t.Fatalf("unexpected failure condition: %+v", failed)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	conds := []metav1.Condition{{Type: "A", Status: metav1.ConditionTrue}}
+
+	if !conditions.Remove(&conds, "A") {
+		t.Error("expected Remove to report the condition was present")
+	}
+	if len(conds) != 0 {
+		t.Errorf("expected the condition to be gone, got %v", conds)
+	}
+	if conditions.Remove(&conds, "A") {
+		t.Error("expected Remove to report nothing to do the second time")
+	}
+}

--- a/conditions/phase.go
+++ b/conditions/phase.go
@@ -1,0 +1,124 @@
+package conditions
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Phase values for resources that expose a coarse `status.phase` alongside
+// conditions. Modules that already ship a different phase vocabulary keep it —
+// see [Aggregate] for building a phase of your own — but new resources should
+// use these.
+const (
+	PhasePending    = "Pending"
+	PhaseInProgress = "InProgress"
+	PhaseError      = "Error"
+	PhaseReady      = "Ready"
+)
+
+// Aggregate folds a set of stage conditions into a single status, following the
+// usual meaning of an aggregate Ready condition:
+//
+//   - Unknown if any stage is missing or Unknown — the controller has not
+//     reached a verdict on every stage yet;
+//   - False if every stage is known and at least one is False;
+//   - True if every stage is True.
+//
+// Missing counts as Unknown rather than being skipped: a stage that has never
+// been evaluated is not evidence that the resource is healthy.
+//
+// Calling Aggregate with no stages returns Unknown — an empty set of evidence
+// says nothing, and reporting True would be actively misleading.
+func Aggregate(conds []metav1.Condition, stages ...string) metav1.ConditionStatus {
+	if len(stages) == 0 {
+		return metav1.ConditionUnknown
+	}
+
+	result := metav1.ConditionTrue
+	for _, t := range stages {
+		c := Get(conds, t)
+		if c == nil || c.Status == metav1.ConditionUnknown {
+			return metav1.ConditionUnknown
+		}
+		if c.Status == metav1.ConditionFalse {
+			result = metav1.ConditionFalse
+		}
+	}
+	return result
+}
+
+// AggregateReady builds the aggregate Ready condition from the given stage
+// conditions. The message names the first stage that is not True, which is what
+// makes `kubectl describe` immediately useful on a resource stuck mid-way.
+func AggregateReady(conds []metav1.Condition, generation int64, stages ...string) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               TypeReady,
+		Status:             Aggregate(conds, stages...),
+		Reason:             ReasonReconciled,
+		ObservedGeneration: generation,
+	}
+
+	if cond.Status == metav1.ConditionTrue {
+		return cond
+	}
+
+	for _, t := range stages {
+		c := Get(conds, t)
+		if c != nil && c.Status == metav1.ConditionTrue {
+			continue
+		}
+
+		cond.Message = "waiting for " + t
+		switch {
+		case c == nil:
+			cond.Reason = ReasonPending
+		case c.Status == metav1.ConditionUnknown:
+			cond.Reason = ReasonPending
+			if c.Message != "" {
+				cond.Message = t + ": " + c.Message
+			}
+		default:
+			cond.Reason = ReasonReconcileFailed
+			if c.Message != "" {
+				cond.Message = t + ": " + c.Message
+			}
+		}
+		return cond
+	}
+
+	// Unreachable while Aggregate and this loop agree on what "not True" means;
+	// keep the fallback so a future change to one of them cannot silently
+	// produce a condition with a stale ReasonReconciled.
+	cond.Reason = ReasonPending
+	return cond
+}
+
+// DerivePhase computes the coarse phase from the stage conditions, using the
+// vocabulary declared above.
+//
+// It is a pure function of the conditions: unlike a state machine it never
+// consults the previous phase, so a stage condition that stops being published
+// can at worst make the phase less specific — it cannot strand the resource in
+// an intermediate phase forever.
+//
+//   - PhasePending    no stage has a verdict yet;
+//   - PhaseError      some stage failed (Reason ReasonReconcileFailed);
+//   - PhaseInProgress some stage is False for a non-terminal reason, such as
+//     waiting on a dependency;
+//   - PhaseReady      every stage is True.
+func DerivePhase(conds []metav1.Condition, stages ...string) string {
+	switch Aggregate(conds, stages...) {
+	case metav1.ConditionTrue:
+		return PhaseReady
+	case metav1.ConditionUnknown:
+		return PhasePending
+	}
+
+	for _, t := range stages {
+		if c := Get(conds, t); c != nil &&
+			c.Status == metav1.ConditionFalse &&
+			c.Reason == ReasonReconcileFailed {
+			return PhaseError
+		}
+	}
+	return PhaseInProgress
+}

--- a/conditions/phase_test.go
+++ b/conditions/phase_test.go
@@ -1,0 +1,202 @@
+package conditions_test
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/sds-common-lib/conditions"
+)
+
+const (
+	stageA = "StageA"
+	stageB = "StageB"
+)
+
+func cond(t string, s metav1.ConditionStatus, reason, msg string) metav1.Condition {
+	return metav1.Condition{Type: t, Status: s, Reason: reason, Message: msg}
+}
+
+func TestAggregate(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		conds []metav1.Condition
+		want  metav1.ConditionStatus
+	}{
+		{
+			name:  "all true",
+			conds: []metav1.Condition{cond(stageA, metav1.ConditionTrue, "", ""), cond(stageB, metav1.ConditionTrue, "", "")},
+			want:  metav1.ConditionTrue,
+		},
+		{
+			name:  "one false",
+			conds: []metav1.Condition{cond(stageA, metav1.ConditionTrue, "", ""), cond(stageB, metav1.ConditionFalse, "", "")},
+			want:  metav1.ConditionFalse,
+		},
+		{
+			name:  "one unknown outranks a false",
+			conds: []metav1.Condition{cond(stageA, metav1.ConditionUnknown, "", ""), cond(stageB, metav1.ConditionFalse, "", "")},
+			want:  metav1.ConditionUnknown,
+		},
+		{
+			// The case that matters: a stage nobody has evaluated must not be
+			// silently skipped, or a resource halfway through reconciliation
+			// reports Ready.
+			name:  "missing stage is unknown, not skipped",
+			conds: []metav1.Condition{cond(stageA, metav1.ConditionTrue, "", "")},
+			want:  metav1.ConditionUnknown,
+		},
+		{
+			name:  "no conditions at all",
+			conds: nil,
+			want:  metav1.ConditionUnknown,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := conditions.Aggregate(tc.conds, stageA, stageB); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAggregate_NoStagesIsUnknown(t *testing.T) {
+	conds := []metav1.Condition{cond(stageA, metav1.ConditionTrue, "", "")}
+	if got := conditions.Aggregate(conds); got != metav1.ConditionUnknown {
+		t.Fatalf("an empty stage list is no evidence of health: got %v", got)
+	}
+}
+
+func TestAggregateReady(t *testing.T) {
+	t.Run("all stages true", func(t *testing.T) {
+		conds := []metav1.Condition{
+			cond(stageA, metav1.ConditionTrue, "", ""),
+			cond(stageB, metav1.ConditionTrue, "", ""),
+		}
+		got := conditions.AggregateReady(conds, 2, stageA, stageB)
+		if got.Status != metav1.ConditionTrue ||
+			got.Reason != conditions.ReasonReconciled ||
+			got.ObservedGeneration != 2 ||
+			got.Message != "" {
+			t.Fatalf("unexpected condition: %+v", got)
+		}
+	})
+
+	t.Run("names the failing stage", func(t *testing.T) {
+		conds := []metav1.Condition{
+			cond(stageA, metav1.ConditionTrue, "", ""),
+			cond(stageB, metav1.ConditionFalse, conditions.ReasonReconcileFailed, "pool missing"),
+		}
+		got := conditions.AggregateReady(conds, 1, stageA, stageB)
+		if got.Status != metav1.ConditionFalse {
+			t.Fatalf("expected False, got %v", got.Status)
+		}
+		if got.Reason != conditions.ReasonReconcileFailed {
+			t.Errorf("expected reason %q, got %q", conditions.ReasonReconcileFailed, got.Reason)
+		}
+		if got.Message != stageB+": pool missing" {
+			t.Errorf("expected the failing stage and its message, got %q", got.Message)
+		}
+	})
+
+	t.Run("reports the first non-true stage in order", func(t *testing.T) {
+		conds := []metav1.Condition{
+			cond(stageA, metav1.ConditionFalse, conditions.ReasonReconcileFailed, "first"),
+			cond(stageB, metav1.ConditionFalse, conditions.ReasonReconcileFailed, "second"),
+		}
+		got := conditions.AggregateReady(conds, 1, stageA, stageB)
+		if got.Message != stageA+": first" {
+			t.Fatalf("expected the earliest failing stage, got %q", got.Message)
+		}
+	})
+
+	t.Run("missing stage is pending", func(t *testing.T) {
+		conds := []metav1.Condition{cond(stageA, metav1.ConditionTrue, "", "")}
+		got := conditions.AggregateReady(conds, 1, stageA, stageB)
+		if got.Status != metav1.ConditionUnknown {
+			t.Fatalf("expected Unknown, got %v", got.Status)
+		}
+		if got.Reason != conditions.ReasonPending {
+			t.Errorf("expected reason %q, got %q", conditions.ReasonPending, got.Reason)
+		}
+		if got.Message != "waiting for "+stageB {
+			t.Errorf("unexpected message %q", got.Message)
+		}
+	})
+}
+
+func TestDerivePhase(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		conds []metav1.Condition
+		want  string
+	}{
+		{
+			name:  "nothing evaluated yet",
+			conds: nil,
+			want:  conditions.PhasePending,
+		},
+		{
+			name:  "partially evaluated",
+			conds: []metav1.Condition{cond(stageA, metav1.ConditionTrue, "", "")},
+			want:  conditions.PhasePending,
+		},
+		{
+			name: "all good",
+			conds: []metav1.Condition{
+				cond(stageA, metav1.ConditionTrue, "", ""),
+				cond(stageB, metav1.ConditionTrue, "", ""),
+			},
+			want: conditions.PhaseReady,
+		},
+		{
+			name: "failed stage",
+			conds: []metav1.Condition{
+				cond(stageA, metav1.ConditionTrue, "", ""),
+				cond(stageB, metav1.ConditionFalse, conditions.ReasonReconcileFailed, ""),
+			},
+			want: conditions.PhaseError,
+		},
+		{
+			name: "waiting on a dependency is not an error",
+			conds: []metav1.Condition{
+				cond(stageA, metav1.ConditionTrue, "", ""),
+				cond(stageB, metav1.ConditionFalse, conditions.ReasonWaitingForDependency, ""),
+			},
+			want: conditions.PhaseInProgress,
+		},
+		{
+			name: "an error anywhere outranks in-progress",
+			conds: []metav1.Condition{
+				cond(stageA, metav1.ConditionFalse, conditions.ReasonReconcileFailed, ""),
+				cond(stageB, metav1.ConditionFalse, conditions.ReasonWaitingForDependency, ""),
+			},
+			want: conditions.PhaseError,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := conditions.DerivePhase(tc.conds, stageA, stageB); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A phase derived from conditions cannot strand a resource: dropping a stage
+// condition degrades the phase to Pending rather than freezing it wherever the
+// previous transition left it, which is the failure mode of a phase-to-phase
+// state machine.
+func TestDerivePhase_IsPureFunctionOfConditions(t *testing.T) {
+	full := []metav1.Condition{
+		cond(stageA, metav1.ConditionTrue, "", ""),
+		cond(stageB, metav1.ConditionTrue, "", ""),
+	}
+	if got := conditions.DerivePhase(full, stageA, stageB); got != conditions.PhaseReady {
+		t.Fatalf("got %q, want %q", got, conditions.PhaseReady)
+	}
+
+	degraded := full[:1]
+	if got := conditions.DerivePhase(degraded, stageA, stageB); got != conditions.PhasePending {
+		t.Fatalf("got %q, want %q", got, conditions.PhasePending)
+	}
+}

--- a/conditions/update.go
+++ b/conditions/update.go
@@ -1,0 +1,65 @@
+package conditions
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// UpdateStatus applies mutate to the latest server-side version of obj and
+// writes the result through the status subresource.
+//
+// It exists because the naive version of this — mutate the object you already
+// have, call Status().Update — has three failure modes that every controller
+// otherwise has to remember to handle:
+//
+//   - a write on every reconcile, including periodic resyncs that change
+//     nothing, which turns a quiet cluster into a steady stream of etcd writes
+//     and watch events. UpdateStatus skips the call entirely when the mutation
+//     is a no-op;
+//   - a lost status update when the object changed between the read and the
+//     write. UpdateStatus retries on conflict against a re-fetched object;
+//   - a stale write that reverts a status another actor set from a newer view
+//     of the world, because mutate ran against a cached copy. UpdateStatus
+//     always mutates freshly-read state.
+//
+// mutate must be free of side effects outside the object: it can run more than
+// once. It is called with an object read from the API server, so it must cope
+// with a nil status pointer.
+//
+// obj itself is left untouched — it is only used for its key and its type.
+// Callers that need the written state must re-read the object.
+func UpdateStatus[T client.Object](
+	ctx context.Context,
+	cl client.Client,
+	obj T,
+	mutate func(T),
+) error {
+	key := client.ObjectKeyFromObject(obj)
+
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh, ok := obj.DeepCopyObject().(T)
+		if !ok {
+			return fmt.Errorf("deep copy of %T did not yield the same type", obj)
+		}
+		if err := cl.Get(ctx, key, fresh); err != nil {
+			return err
+		}
+
+		before, ok := fresh.DeepCopyObject().(T)
+		if !ok {
+			return fmt.Errorf("deep copy of %T did not yield the same type", fresh)
+		}
+
+		mutate(fresh)
+
+		if equality.Semantic.DeepEqual(before, fresh) {
+			return nil
+		}
+
+		return cl.Status().Update(ctx, fresh)
+	})
+}

--- a/conditions/update_test.go
+++ b/conditions/update_test.go
@@ -1,0 +1,175 @@
+package conditions_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/deckhouse/sds-common-lib/conditions"
+)
+
+func newPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "target", Namespace: "default"},
+	}
+}
+
+func newClient(t *testing.T, objs ...client.Object) client.WithWatch {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(&corev1.Pod{}).
+		Build()
+}
+
+func readPod(t *testing.T, cl client.Client) *corev1.Pod {
+	t.Helper()
+	got := &corev1.Pod{}
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: "target", Namespace: "default"}, got); err != nil {
+		t.Fatalf("reading the pod back: %v", err)
+	}
+	return got
+}
+
+func TestUpdateStatus_WritesMutation(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+
+	err := conditions.UpdateStatus(context.Background(), cl, pod, func(p *corev1.Pod) {
+		p.Status.Message = "written"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	if got := readPod(t, cl).Status.Message; got != "written" {
+		t.Fatalf("expected the mutation to be persisted, got %q", got)
+	}
+}
+
+func TestUpdateStatus_SkipsNoOpWrite(t *testing.T) {
+	pod := newPod()
+	pod.Status.Message = "unchanged"
+	cl := newClient(t, pod)
+
+	before := readPod(t, cl).ResourceVersion
+
+	err := conditions.UpdateStatus(context.Background(), cl, pod, func(p *corev1.Pod) {
+		p.Status.Message = "unchanged"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	// A write that changes nothing must not reach the API server at all,
+	// otherwise every periodic resync produces an etcd write and a watch event
+	// for every object the controller owns.
+	if after := readPod(t, cl).ResourceVersion; after != before {
+		t.Fatalf("expected no write, resourceVersion moved %s -> %s", before, after)
+	}
+}
+
+func TestUpdateStatus_MutatesFreshState(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+
+	// Somebody else advanced the status after our caller read the object.
+	current := readPod(t, cl)
+	current.Status.Reason = "SetByAnotherActor"
+	if err := cl.Status().Update(context.Background(), current); err != nil {
+		t.Fatalf("seeding concurrent update: %v", err)
+	}
+
+	var observed string
+	err := conditions.UpdateStatus(context.Background(), cl, pod, func(p *corev1.Pod) {
+		observed = p.Status.Reason
+		p.Status.Message = "written"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	if observed != "SetByAnotherActor" {
+		t.Errorf("mutate ran against stale state: saw reason %q", observed)
+	}
+	if got := readPod(t, cl).Status.Reason; got != "SetByAnotherActor" {
+		t.Errorf("the concurrent update was reverted, reason is %q", got)
+	}
+}
+
+func TestUpdateStatus_RetriesOnConflict(t *testing.T) {
+	pod := newPod()
+
+	calls := 0
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(pod).
+		WithStatusSubresource(&corev1.Pod{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(
+				ctx context.Context,
+				c client.Client,
+				subResourceName string,
+				obj client.Object,
+				opts ...client.SubResourceUpdateOption,
+			) error {
+				calls++
+				if calls == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Resource: "pods"}, obj.GetName(), nil)
+				}
+				return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	err := conditions.UpdateStatus(context.Background(), cl, pod, func(p *corev1.Pod) {
+		p.Status.Message = "written"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatus should have retried past the conflict: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 update attempts, got %d", calls)
+	}
+	if got := readPod(t, cl).Status.Message; got != "written" {
+		t.Errorf("expected the retry to persist the mutation, got %q", got)
+	}
+}
+
+func TestUpdateStatus_LeavesCallerObjectUntouched(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+
+	err := conditions.UpdateStatus(context.Background(), cl, pod, func(p *corev1.Pod) {
+		p.Status.Message = "written"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatus: %v", err)
+	}
+
+	if pod.Status.Message != "" {
+		t.Fatalf("caller's object was mutated: %q", pod.Status.Message)
+	}
+}
+
+func TestUpdateStatus_PropagatesGetError(t *testing.T) {
+	// The object does not exist, so the read inside UpdateStatus fails.
+	cl := newClient(t)
+
+	err := conditions.UpdateStatus(context.Background(), cl, newPod(), func(p *corev1.Pod) {
+		p.Status.Message = "written"
+	})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected a NotFound error, got %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,9 @@ require (
 	github.com/onsi/gomega v1.38.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.2
+	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.3
+	k8s.io/client-go v0.32.1
 	sigs.k8s.io/controller-runtime v0.20.4
 )
 
@@ -44,6 +46,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
@@ -69,10 +72,9 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241216192217-9240e9c98484 // indirect
 	google.golang.org/grpc v1.69.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.32.1 // indirect
-	k8s.io/client-go v0.32.1 // indirect
 	k8s.io/component-base v0.32.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect


### PR DESCRIPTION
## Why

A review of the CRDs across the storage modules found `status.conditions` published a dozen different ways: some modules hand-roll the set-if-changed logic, some write the status on every reconcile, and several publish no conditions at all and expose only a coarse `status.phase`. This package is the single implementation they will be migrated onto, one module at a time.

It works on a plain `*[]metav1.Condition` rather than on a Getter/Setter interface: the CRD status types are a mix of value and pointer structs, and none of them implement a common interface today. Taking the slice directly means the helper can be adopted without touching every api package first.

## What is in it

**`conditions.go`** — `Set` / `Remove` / `Get` / `IsTrue` / `IsFalse` / `IsUnknown` over apimachinery's meta helpers, a shared reason vocabulary, and `Ready(generation, err)`, which turns the outcome of a reconcile pass into the aggregate Ready condition in one line.

Separately, `IsStale(conds, type, generation)` — the `observedGeneration` check that distinguishes "reconciled and healthy" from "the controller has not seen your latest spec change yet". This is something `status.phase` cannot express at all, and it is what every "wait for the dependency to become ready" gate needs.

**`phase.go`** — `Aggregate` / `AggregateReady` / `DerivePhase` for resources with staged reconciliation.

Two deliberate differences from the implementation currently duplicated in sds-object and sds-elastic:

- a missing stage aggregates to `Unknown` instead of being skipped. In the existing `derivePhase`, the `c == nil → continue` branch means a resource with a non-empty condition list but no stage evaluated yet reports `Ready`;
- `AggregateReady` puts the name of the first non-`True` stage into the message, so `kubectl describe` immediately shows where the resource is stuck.

`DerivePhase` is a pure function of the conditions: it never consults the previous phase. A phase-to-phase state machine cannot do that, which is exactly why in csi-scsi-generic a condition that is never published strands a device in an intermediate phase forever.

**`update.go`** — `UpdateStatus` with three safety nets: the mutation is applied to freshly-read state, the write is skipped entirely when the mutation changes nothing, and conflicts are retried. The naive version (mutate the object you already hold, call `Status().Update`) produces an etcd write on every periodic resync, loses the status under a race, and can revert another actor's update.

## Verified

- `go test ./conditions/` — green, 89.7% coverage;
- `golangci-lint run --build-tags ce` — 0 issues;
- `go build ./...` and the full repository test suite pass.

## About go.mod

`k8s.io/client-go` moves from indirect to direct (`util/retry` in `update.go`), and `k8s.io/api` follows for the tests. Both were already in the module graph, so no new top-level dependency is introduced.
