### PR TITLE
feat(conditions): carry a message, cap every message, add Stages

### DIFF
--- a/conditions/conditions.go
+++ b/conditions/conditions.go
@@ -12,6 +12,8 @@
 package conditions
 
 import (
+	"unicode/utf8"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -122,6 +124,37 @@ func SemanticallyEqual(a, b *metav1.Condition) bool {
 		a.ObservedGeneration == b.ObservedGeneration
 }
 
+// MaxMessageLen is the longest condition.message the apiserver will accept.
+//
+// It is the MaxLength that metav1.Condition declares on the field, so every CRD
+// that embeds the standard condition schema carries it. The apiserver counts
+// characters rather than bytes, so the limit is in runes.
+//
+// It matters because the check is on the whole status update: one message over
+// the cap is rejected as a unit, and the resource is then left with whatever
+// conditions it had before — or with none at all, which is indistinguishable
+// from "never evaluated". A controller whose message is built from an error it
+// did not produce cannot bound its length, so the builders here truncate.
+const MaxMessageLen = 32768
+
+// TruncateMessage clips msg to what condition.message accepts, marking the cut
+// with an ellipsis so a reader can tell the text is incomplete.
+//
+// Exported because a module that shapes a condition of its own — a stage
+// condition, a kind-specific type — needs the same bound, and re-deriving it
+// per module is how the constant drifts from the schema.
+func TruncateMessage(msg string) string {
+	// Counted rather than converted: every condition this package builds goes
+	// through here, and almost none of them are anywhere near the cap. Taking
+	// []rune first would copy the whole string on every call just to measure it.
+	if utf8.RuneCountInString(msg) <= MaxMessageLen {
+		return msg
+	}
+
+	const ellipsis = "..."
+	return string([]rune(msg)[:MaxMessageLen-utf8.RuneCountInString(ellipsis)]) + ellipsis
+}
+
 // Ready builds the aggregate Ready condition for a reconcile pass that ended
 // with err (nil on success). It is the one-liner behind the uniform behaviour
 // of the single-stage controllers:
@@ -131,18 +164,55 @@ func SemanticallyEqual(a, b *metav1.Condition) bool {
 // On failure the error text becomes the message, so err should be wrapped with
 // enough context to be readable in `kubectl describe` — and must not carry
 // secrets, since conditions are world-readable to anyone who can get the
-// resource.
+// resource. The message is truncated to [MaxMessageLen].
+//
+// A successful pass gets no message. Use [ReadyWithMessage] to have it report
+// what it achieved.
 func Ready(generation int64, err error) metav1.Condition {
-	cond := metav1.Condition{
+	return ReadyWithMessage(generation, "", err)
+}
+
+// ReadyWithMessage builds the aggregate Ready condition for a reconcile pass
+// that ended with err (nil on success) and described its own outcome as msg.
+//
+// msg is what a successful pass has to say for itself, and it is carried rather
+// than derived from the kind because a pass can succeed without having done
+// everything the kind eventually does — the resource it was waiting on did not
+// exist yet, an optional CRD is not registered in the cluster. A fixed "has been
+// reconciled" would state something the controller does not know to be true,
+// and an empty message is what `kubectl describe` shows next to the condition.
+//
+// An empty msg is left empty rather than given a default, for the same reason.
+// A caller that does want a fixed fallback supplies it and keeps the choice
+// visible at its own call site:
+//
+//	conditions.ReadyWithMessage(generation, cmp.Or(msg, "the resource has been reconciled"), err)
+//
+// On failure msg is dropped in favour of the error text: once a pass has failed,
+// what it managed to do before that is not what an operator needs to read first.
+// Callers wanting both should wrap the error with the context instead.
+//
+// Neither msg nor err must carry secrets: conditions are readable by anyone who
+// can get the resource, and a backend error text routinely echoes the request it
+// failed on, credentials in the URL included.
+//
+// Both messages are truncated to [MaxMessageLen].
+func ReadyWithMessage(generation int64, msg string, err error) metav1.Condition {
+	if err != nil {
+		return metav1.Condition{
+			Type:               TypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonReconcileFailed,
+			Message:            TruncateMessage(err.Error()),
+			ObservedGeneration: generation,
+		}
+	}
+
+	return metav1.Condition{
 		Type:               TypeReady,
 		Status:             metav1.ConditionTrue,
 		Reason:             ReasonReconciled,
+		Message:            TruncateMessage(msg),
 		ObservedGeneration: generation,
 	}
-	if err != nil {
-		cond.Status = metav1.ConditionFalse
-		cond.Reason = ReasonReconcileFailed
-		cond.Message = err.Error()
-	}
-	return cond
 }

--- a/conditions/conditions_test.go
+++ b/conditions/conditions_test.go
@@ -2,8 +2,10 @@ package conditions_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -193,5 +195,110 @@ func TestRemove(t *testing.T) {
 	}
 	if conditions.Remove(&conds, "A") {
 		t.Error("expected Remove to report nothing to do the second time")
+	}
+}
+
+// Ready predates ReadyWithMessage and is called by controllers already released
+// against this package, so its output has to stay exactly what it was: a
+// successful pass carries no message.
+//
+// The temptation is to give it a default like "reconciled" now that the field is
+// threaded through — that would silently rewrite the status of every existing
+// caller and, worse, assert something the pass never claimed.
+func TestReadyLeavesASuccessMessageEmpty(t *testing.T) {
+	if got := conditions.Ready(1, nil).Message; got != "" {
+		t.Errorf("message = %q, want it empty; Ready must not invent one", got)
+	}
+}
+
+func TestReadyWithMessage(t *testing.T) {
+	ok := conditions.ReadyWithMessage(5, "the backend is in place", nil)
+	if ok.Status != metav1.ConditionTrue ||
+		ok.Reason != conditions.ReasonReconciled ||
+		ok.ObservedGeneration != 5 ||
+		ok.Message != "the backend is in place" {
+		t.Fatalf("unexpected success condition: %+v", ok)
+	}
+
+	// The error text wins: what the pass managed before it failed is not what an
+	// operator needs to read first.
+	failed := conditions.ReadyWithMessage(5, "the backend is in place", errors.New("boom"))
+	if failed.Status != metav1.ConditionFalse ||
+		failed.Reason != conditions.ReasonReconcileFailed ||
+		failed.ObservedGeneration != 5 ||
+		failed.Message != "boom" {
+		t.Fatalf("unexpected failure condition: %+v", failed)
+	}
+}
+
+// An over-long message is rejected by the apiserver as part of the whole status
+// update, so the resource ends up with no condition at all rather than a clipped
+// one. Truncating here is what keeps a verdict readable instead of absent.
+func TestTruncateMessage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want int // expected rune length
+	}{
+		{"short", "boom", 4},
+		{"exactly at the limit", strings.Repeat("x", conditions.MaxMessageLen), conditions.MaxMessageLen},
+		{"one over", strings.Repeat("x", conditions.MaxMessageLen+1), conditions.MaxMessageLen},
+		{"far over", strings.Repeat("x", conditions.MaxMessageLen*3), conditions.MaxMessageLen},
+		// The apiserver counts characters, so a message of multi-byte runes is
+		// well under the cap in runes while being three times the cap in bytes.
+		// Truncating on bytes would mangle it for no reason.
+		{"multi-byte runes under the limit", strings.Repeat("тест", 100), 400},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conditions.TruncateMessage(tc.in)
+			if n := len([]rune(got)); n != tc.want {
+				t.Errorf("length = %d runes, want %d", n, tc.want)
+			}
+			if len([]rune(tc.in)) <= conditions.MaxMessageLen {
+				if got != tc.in {
+					t.Error("a message within the limit must come back unchanged")
+				}
+				return
+			}
+			if !strings.HasSuffix(got, "...") {
+				t.Errorf("a truncated message must be marked as cut, got %q", got[len(got)-8:])
+			}
+		})
+	}
+}
+
+// Multi-byte runes exactly at the boundary: cutting on bytes would both overshoot
+// the character count and be able to split a rune into invalid UTF-8.
+func TestTruncateMessageCutsOnRunesNotBytes(t *testing.T) {
+	in := strings.Repeat("т", conditions.MaxMessageLen+10)
+
+	got := conditions.TruncateMessage(in)
+
+	if n := len([]rune(got)); n != conditions.MaxMessageLen {
+		t.Errorf("length = %d runes, want %d", n, conditions.MaxMessageLen)
+	}
+	if !utf8.ValidString(got) {
+		t.Error("truncation produced invalid UTF-8")
+	}
+}
+
+func TestReadyTruncatesALongError(t *testing.T) {
+	long := errors.New(strings.Repeat("x", conditions.MaxMessageLen*2))
+
+	for name, cond := range map[string]metav1.Condition{
+		"Ready":            conditions.Ready(1, long),
+		"ReadyWithMessage": conditions.ReadyWithMessage(1, "", long),
+	} {
+		if n := len([]rune(cond.Message)); n > conditions.MaxMessageLen {
+			t.Errorf("%s: message = %d runes, want at most %d", name, n, conditions.MaxMessageLen)
+		}
+	}
+}
+
+func TestReadyWithMessageTruncatesALongSuccessMessage(t *testing.T) {
+	cond := conditions.ReadyWithMessage(1, strings.Repeat("x", conditions.MaxMessageLen*2), nil)
+
+	if n := len([]rune(cond.Message)); n > conditions.MaxMessageLen {
+		t.Errorf("message = %d runes, want at most %d", n, conditions.MaxMessageLen)
 	}
 }

--- a/conditions/phase.go
+++ b/conditions/phase.go
@@ -29,67 +29,21 @@ const (
 // Calling Aggregate with no stages returns Unknown — an empty set of evidence
 // says nothing, and reporting True would be actively misleading.
 func Aggregate(conds []metav1.Condition, stages ...string) metav1.ConditionStatus {
-	if len(stages) == 0 {
-		return metav1.ConditionUnknown
-	}
-
-	result := metav1.ConditionTrue
-	for _, t := range stages {
-		c := Get(conds, t)
-		if c == nil || c.Status == metav1.ConditionUnknown {
-			return metav1.ConditionUnknown
-		}
-		if c.Status == metav1.ConditionFalse {
-			result = metav1.ConditionFalse
-		}
-	}
-	return result
+	return Stages{Types: stages}.Aggregate(conds)
 }
 
 // AggregateReady builds the aggregate Ready condition from the given stage
 // conditions. The message names the first stage that is not True, which is what
 // makes `kubectl describe` immediately useful on a resource stuck mid-way.
+//
+// A True aggregate carries no message: this builds a condition, it does not know
+// what the pass achieved. [Stages.SetReady] writes one that says.
+//
+// The message is truncated to [MaxMessageLen]. It has to be: a stage message
+// that is itself right at the cap comes back out of here with a stage-name
+// prefix in front of it, which is over.
 func AggregateReady(conds []metav1.Condition, generation int64, stages ...string) metav1.Condition {
-	cond := metav1.Condition{
-		Type:               TypeReady,
-		Status:             Aggregate(conds, stages...),
-		Reason:             ReasonReconciled,
-		ObservedGeneration: generation,
-	}
-
-	if cond.Status == metav1.ConditionTrue {
-		return cond
-	}
-
-	for _, t := range stages {
-		c := Get(conds, t)
-		if c != nil && c.Status == metav1.ConditionTrue {
-			continue
-		}
-
-		cond.Message = "waiting for " + t
-		switch {
-		case c == nil:
-			cond.Reason = ReasonPending
-		case c.Status == metav1.ConditionUnknown:
-			cond.Reason = ReasonPending
-			if c.Message != "" {
-				cond.Message = t + ": " + c.Message
-			}
-		default:
-			cond.Reason = ReasonReconcileFailed
-			if c.Message != "" {
-				cond.Message = t + ": " + c.Message
-			}
-		}
-		return cond
-	}
-
-	// Unreachable while Aggregate and this loop agree on what "not True" means;
-	// keep the fallback so a future change to one of them cannot silently
-	// produce a condition with a stale ReasonReconciled.
-	cond.Reason = ReasonPending
-	return cond
+	return Stages{Types: stages}.ReadyCondition(conds, generation)
 }
 
 // DerivePhase computes the coarse phase from the stage conditions, using the
@@ -106,19 +60,5 @@ func AggregateReady(conds []metav1.Condition, generation int64, stages ...string
 //     waiting on a dependency;
 //   - PhaseReady      every stage is True.
 func DerivePhase(conds []metav1.Condition, stages ...string) string {
-	switch Aggregate(conds, stages...) {
-	case metav1.ConditionTrue:
-		return PhaseReady
-	case metav1.ConditionUnknown:
-		return PhasePending
-	}
-
-	for _, t := range stages {
-		if c := Get(conds, t); c != nil &&
-			c.Status == metav1.ConditionFalse &&
-			c.Reason == ReasonReconcileFailed {
-			return PhaseError
-		}
-	}
-	return PhaseInProgress
+	return Stages{Types: stages}.Phase(conds)
 }

--- a/conditions/phase_test.go
+++ b/conditions/phase_test.go
@@ -1,6 +1,7 @@
 package conditions_test
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,5 +199,30 @@ func TestDerivePhase_IsPureFunctionOfConditions(t *testing.T) {
 	degraded := full[:1]
 	if got := conditions.DerivePhase(degraded, stageA, stageB); got != conditions.PhasePending {
 		t.Fatalf("got %q, want %q", got, conditions.PhasePending)
+	}
+}
+
+// A stage message that is itself at the cap gets a stage-name prefix here, which
+// puts the aggregate over it. That would make the apiserver reject the whole
+// status update — dropping the stage conditions too, so the resource ends up
+// reporting nothing about a failure it had already diagnosed.
+func TestAggregateReadyTruncatesAStageMessage(t *testing.T) {
+	conds := []metav1.Condition{{
+		Type:    stageA,
+		Status:  metav1.ConditionFalse,
+		Reason:  conditions.ReasonReconcileFailed,
+		Message: strings.Repeat("x", conditions.MaxMessageLen),
+	}}
+
+	cond := conditions.AggregateReady(conds, 1, stageA)
+
+	if cond.Status != metav1.ConditionFalse {
+		t.Fatalf("status = %q, want %q", cond.Status, metav1.ConditionFalse)
+	}
+	if n := len([]rune(cond.Message)); n > conditions.MaxMessageLen {
+		t.Errorf("message = %d runes, want at most %d", n, conditions.MaxMessageLen)
+	}
+	if !strings.HasPrefix(cond.Message, stageA+": ") {
+		t.Error("the message must still name the stage it came from")
 	}
 }

--- a/conditions/stages.go
+++ b/conditions/stages.go
@@ -1,0 +1,434 @@
+package conditions
+
+import (
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Stages describes an ordered set of stage conditions that a reconcile walks in
+// order, together with the vocabulary it reports them with.
+//
+// It exists because two of the storage modules had grown the same state machine
+// independently — accumulate a condition per stage, mark everything downstream
+// as blocked when one does not pass, fold the lot into an aggregate Ready — and
+// the copies had already drifted apart. The type carries only the condition
+// handling: the status builders those modules flush through are full of their
+// own fields and stay where they are.
+//
+// The zero vocabulary is this package's own, so a caller that only fills Types
+// gets the same behaviour the package-level [Aggregate], [AggregateReady] and
+// [DerivePhase] give. A module with a vocabulary of its own fills the rest
+// rather than rewriting the machine around it.
+type Stages struct {
+	// Types are the stage condition types, in the order the reconcile walks
+	// them. The order is what Gate uses to decide what is downstream.
+	Types []string
+
+	// ReadyType is the aggregate condition gated when a stage does not pass.
+	// Defaults to [TypeReady].
+	ReadyType string
+
+	// Passed is the reason recorded on a stage that completed.
+	// Defaults to [ReasonReconciled].
+	Passed string
+	// Failed is the reason recorded on a stage that returned an error, and the
+	// one [Stages.Phase] reads as a failure rather than as work in progress.
+	// Defaults to [ReasonReconcileFailed].
+	Failed string
+	// InProgress is the reason recorded on a stage that has not finished and
+	// did not fail. Defaults to [ReasonPending].
+	InProgress string
+	// Blocked is the reason recorded on the stages downstream of one that did
+	// not pass, and on the aggregate. Defaults to [ReasonWaitingForDependency].
+	Blocked string
+
+	// SkipMissing treats a stage that has no condition as carrying no evidence
+	// either way, instead of as Unknown.
+	//
+	// The default — missing counts as Unknown — is the safer reading: a stage
+	// that has never been evaluated is not evidence that the resource is
+	// healthy. Modules that shipped the other behaviour set this so that moving
+	// onto this type does not change what their users see, and can tighten it
+	// afterwards as a change of its own.
+	//
+	// Even with SkipMissing, a resource where no stage has a verdict at all
+	// aggregates to Unknown: skipping every stage would otherwise report a
+	// brand-new resource as ready.
+	//
+	// It covers a missing stage only. A stage present with status Unknown stays
+	// Unknown either way: it says the controller looked and could not tell,
+	// which is evidence, unlike the absence of a condition.
+	SkipMissing bool
+}
+
+// Validate reports what is wrong with the stage set, or nil when it is usable.
+//
+// The methods here take stage names as plain strings and do not check them
+// against Types: a name that is not there produces a condition [Stages.Aggregate]
+// never reads, and the resource then reports Unknown forever with no other
+// symptom to go on. Validate is what turns that class of typo into a message.
+//
+// Call it where the Stages value is built — a controller's constructor, or a
+// test of the package that declares it — not on every reconcile.
+func (s Stages) Validate() error {
+	if len(s.Types) == 0 {
+		return errors.New("no stage types")
+	}
+
+	seen := make(map[string]struct{}, len(s.Types))
+	for _, t := range s.Types {
+		if t == "" {
+			return errors.New("an empty stage type")
+		}
+		if _, dup := seen[t]; dup {
+			return fmt.Errorf("stage %q is listed twice", t)
+		}
+		seen[t] = struct{}{}
+	}
+
+	if _, clash := seen[s.readyType()]; clash {
+		return fmt.Errorf("the aggregate type %q is also a stage", s.readyType())
+	}
+	return nil
+}
+
+// Known reports whether stage is one of Types.
+//
+// Use it wherever the stage name is not a constant — computed, or taken from a
+// spec — since the methods that take one accept any string.
+func (s Stages) Known(stage string) bool {
+	for _, t := range s.Types {
+		if t == stage {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Stages) readyType() string {
+	if s.ReadyType == "" {
+		return TypeReady
+	}
+	return s.ReadyType
+}
+
+func (s Stages) passed() string {
+	if s.Passed == "" {
+		return ReasonReconciled
+	}
+	return s.Passed
+}
+
+func (s Stages) failed() string {
+	if s.Failed == "" {
+		return ReasonReconcileFailed
+	}
+	return s.Failed
+}
+
+func (s Stages) inProgress() string {
+	if s.InProgress == "" {
+		return ReasonPending
+	}
+	return s.InProgress
+}
+
+func (s Stages) blocked() string {
+	if s.Blocked == "" {
+		return ReasonWaitingForDependency
+	}
+	return s.Blocked
+}
+
+// Aggregate folds the stage conditions into a single status:
+//
+//   - Unknown if a stage is missing or Unknown — the controller has not reached
+//     a verdict on every stage yet;
+//   - False if every stage is known and at least one is False;
+//   - True if every stage is True.
+//
+// With no stages the answer is Unknown: an empty set of evidence says nothing,
+// and reporting True would be actively misleading.
+//
+// See [Stages.SkipMissing] for how a missing stage is counted.
+func (s Stages) Aggregate(conds []metav1.Condition) metav1.ConditionStatus {
+	if len(s.Types) == 0 {
+		return metav1.ConditionUnknown
+	}
+
+	result := metav1.ConditionTrue
+	evidence := false
+
+	for _, t := range s.Types {
+		c := Get(conds, t)
+		if c == nil {
+			if s.SkipMissing {
+				continue
+			}
+			return metav1.ConditionUnknown
+		}
+		if c.Status == metav1.ConditionUnknown {
+			return metav1.ConditionUnknown
+		}
+
+		evidence = true
+		if c.Status == metav1.ConditionFalse {
+			result = metav1.ConditionFalse
+		}
+	}
+
+	if !evidence {
+		return metav1.ConditionUnknown
+	}
+	return result
+}
+
+// ReadyCondition builds the aggregate condition from the stage conditions. The
+// message names the first stage that is not True, which is what makes
+// `kubectl describe` immediately useful on a resource stuck mid-way.
+//
+// A True aggregate carries no message: this builds a condition, it does not know
+// what the pass achieved. Use [Stages.SetReady] to write one that says.
+//
+// The message is truncated to [MaxMessageLen]. It has to be: a stage message
+// that is itself right at the cap comes back out of here with a stage-name
+// prefix in front of it, which is over.
+func (s Stages) ReadyCondition(conds []metav1.Condition, generation int64) metav1.Condition {
+	cond := metav1.Condition{
+		Type:               s.readyType(),
+		Status:             s.Aggregate(conds),
+		Reason:             s.passed(),
+		ObservedGeneration: generation,
+	}
+
+	if cond.Status == metav1.ConditionTrue {
+		return cond
+	}
+
+	for _, t := range s.Types {
+		c := Get(conds, t)
+		if c != nil && c.Status == metav1.ConditionTrue {
+			continue
+		}
+		if c == nil && s.SkipMissing {
+			continue
+		}
+
+		cond.Message = "waiting for " + t
+		switch {
+		case c == nil:
+			cond.Reason = s.inProgress()
+		case c.Status == metav1.ConditionUnknown:
+			cond.Reason = s.inProgress()
+			if c.Message != "" {
+				cond.Message = t + ": " + c.Message
+			}
+		default:
+			cond.Reason = s.failed()
+			if c.Message != "" {
+				cond.Message = t + ": " + c.Message
+			}
+		}
+		cond.Message = TruncateMessage(cond.Message)
+		return cond
+	}
+
+	// Reached when every stage is missing and SkipMissing is set, or if
+	// Aggregate and this loop ever disagree about what "not True" means. Either
+	// way the aggregate is not True, so it must not keep the passed reason.
+	cond.Reason = s.inProgress()
+	return cond
+}
+
+// SetReady writes the aggregate condition and reports whether anything changed.
+//
+// It is the third part of the machine [Stages.Advance] and [Stages.Gate]
+// implement, and the part every module had been writing by hand: a reconcile
+// that walked every stage has to say so on the aggregate, and the other two only
+// ever write it on the paths where a stage did not pass. A controller that
+// finishes a clean pass without calling this leaves the aggregate saying
+// whatever the last failure said — False, forever, on a resource that converged.
+//
+// msg is what a successful pass has to say for itself, with the semantics
+// [ReadyWithMessage] gives it: carried rather than derived, because walking every
+// stage is not the same as having done everything the kind eventually does. It
+// is used only when the aggregate is True; below that the message naming the
+// stage that is not passing is the one an operator needs, and msg is dropped.
+//
+// It must not carry secrets: conditions are readable by anyone who can get the
+// resource. The message is truncated to [MaxMessageLen].
+func (s Stages) SetReady(conds *[]metav1.Condition, generation int64, msg string) bool {
+	cond := s.ReadyCondition(*conds, generation)
+	if cond.Status == metav1.ConditionTrue {
+		cond.Message = TruncateMessage(msg)
+	}
+	return Set(conds, cond)
+}
+
+// Phase computes the coarse phase from the stage conditions, using the
+// vocabulary declared in this package.
+//
+// It is a pure function of the conditions: unlike a state machine it never
+// consults the previous phase, so a stage condition that stops being published
+// can at worst make the phase less specific — it cannot strand the resource in
+// an intermediate phase forever.
+//
+//   - PhasePending    no stage has a verdict yet;
+//   - PhaseError      some stage failed, with the [Stages.Failed] reason;
+//   - PhaseInProgress some stage is False for another reason, such as waiting
+//     on a dependency;
+//   - PhaseReady      every stage is True.
+func (s Stages) Phase(conds []metav1.Condition) string {
+	switch s.Aggregate(conds) {
+	case metav1.ConditionTrue:
+		return PhaseReady
+	case metav1.ConditionUnknown:
+		return PhasePending
+	}
+
+	for _, t := range s.Types {
+		if c := Get(conds, t); c != nil &&
+			c.Status == metav1.ConditionFalse &&
+			c.Reason == s.failed() {
+			return PhaseError
+		}
+	}
+	return PhaseInProgress
+}
+
+// Pass records a stage that completed. The reconcile may proceed to the next
+// one; nothing else is touched, including the aggregate — see [Stages.SetReady]
+// for the end of a clean pass.
+//
+// message is what the stage has to say for itself and is what `kubectl describe`
+// shows next to it. It must not carry secrets, and is truncated to
+// [MaxMessageLen].
+func (s Stages) Pass(conds *[]metav1.Condition, generation int64, stage, message string) {
+	s.set(conds, generation, stage, metav1.ConditionTrue, s.passed(), message)
+}
+
+// Fail records a stage that returned an error, and gates everything downstream
+// of it along with the aggregate — see [Stages.Gate].
+//
+// The error text becomes the stage's message, so err should be wrapped with
+// enough context to be readable in `kubectl describe`, and must not carry
+// secrets: conditions are readable by anyone who can get the resource, and a
+// backend error routinely echoes the request it failed on. It is truncated to
+// [MaxMessageLen].
+//
+// A nil err records a failure with no detail rather than panicking: this runs
+// inside a reconcile, where taking the controller down is the worse of the two.
+func (s Stages) Fail(conds *[]metav1.Condition, generation int64, stage string, err error) {
+	msg := "unspecified error"
+	if err != nil {
+		msg = err.Error()
+	}
+
+	s.set(conds, generation, stage, metav1.ConditionFalse, s.failed(), msg)
+	s.Gate(conds, generation, stage)
+}
+
+// Wait records a stage that has not finished and did not fail, and gates
+// everything downstream of it along with the aggregate — see [Stages.Gate].
+//
+// reason overrides [Stages.InProgress]; empty means that default.
+func (s Stages) Wait(conds *[]metav1.Condition, generation int64, stage, reason, message string) {
+	if reason == "" {
+		reason = s.inProgress()
+	}
+
+	s.set(conds, generation, stage, metav1.ConditionFalse, reason, message)
+	s.Gate(conds, generation, stage)
+}
+
+// Advance records the outcome of one stage and reports whether the reconcile may
+// proceed to the next. It is [Stages.Pass], [Stages.Fail] and [Stages.Wait]
+// behind a single call.
+//
+// It exists for the shape the modules' own loops already have — a done computed
+// above and checked as `if !advance(...) { return }`. New code reads better with
+// the three: the outcome is in the name of the method rather than in a bare
+// true/false several arguments in, and reason cannot be handed to a path that
+// ignores it.
+//
+// err takes precedence over done.
+func (s Stages) Advance(
+	conds *[]metav1.Condition,
+	generation int64,
+	stage string,
+	done bool,
+	reason, message string,
+	err error,
+) bool {
+	switch {
+	case err != nil:
+		s.Fail(conds, generation, stage, err)
+	case !done:
+		s.Wait(conds, generation, stage, reason, message)
+	default:
+		s.Pass(conds, generation, stage, message)
+		return true
+	}
+	return false
+}
+
+// Gate marks every stage after afterStage as False with the [Stages.Blocked]
+// reason, and rewrites the aggregate.
+//
+// The stage named by afterStage is left alone: whoever gated on it has already
+// said why. A condition type that is not in Types is left alone too, which is
+// how a signal condition published on its own schedule keeps its value while the
+// stages around it are blocked.
+//
+// The aggregate goes through [Stages.ReadyCondition] rather than being given the
+// blocked reason directly, so that there is one answer to what Ready says no
+// matter which path reached it. It matters on the path a controller actually
+// takes: `if !s.Advance(...) { return }` returns without computing the aggregate
+// again, and a Ready reading WaitingForDependency / "waiting for StorageReady"
+// would hide the failure whose text is sitting one condition away.
+func (s Stages) Gate(conds *[]metav1.Condition, generation int64, afterStage string) {
+	msg := "waiting for " + afterStage
+
+	after := -1
+	for i, t := range s.Types {
+		if t == afterStage {
+			after = i + 1
+			break
+		}
+	}
+	if after >= 0 {
+		for _, t := range s.Types[after:] {
+			s.set(conds, generation, t, metav1.ConditionFalse, s.blocked(), msg)
+		}
+	}
+
+	cond := s.ReadyCondition(*conds, generation)
+	if cond.Status == metav1.ConditionTrue {
+		// Only reachable when afterStage is not one of Types — a caller's typo,
+		// which [Stages.Validate] is there to catch. The stage conditions then
+		// know nothing about the failure that got here, so they all read True.
+		// Say the least misleading thing rather than call the resource ready.
+		cond.Status = metav1.ConditionFalse
+		cond.Reason = s.blocked()
+		cond.Message = TruncateMessage(msg)
+	}
+	Set(conds, cond)
+}
+
+func (s Stages) set(
+	conds *[]metav1.Condition,
+	generation int64,
+	condType string,
+	status metav1.ConditionStatus,
+	reason, message string,
+) {
+	Set(conds, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		Reason:             reason,
+		Message:            TruncateMessage(message),
+		ObservedGeneration: generation,
+	})
+}

--- a/conditions/stages_test.go
+++ b/conditions/stages_test.go
@@ -1,0 +1,630 @@
+package conditions_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/deckhouse/sds-common-lib/conditions"
+)
+
+func types(conds []metav1.Condition) []string {
+	out := make([]string, 0, len(conds))
+	for _, c := range conds {
+		out = append(out, c.Type)
+	}
+	return out
+}
+
+func find(t *testing.T, conds []metav1.Condition, condType string) metav1.Condition {
+	t.Helper()
+	c := conditions.Get(conds, condType)
+	if c == nil {
+		t.Fatalf("condition %s was not set", condType)
+	}
+	return *c
+}
+
+// The zero vocabulary has to be this package's own, so that a caller who fills
+// only Types gets what the package-level functions give. Asserted through the
+// conditions that come out, since the reason strings are what a module's alerts
+// and dashboards are keyed on.
+func TestStagesDefaultsToThePackageVocabulary(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+
+	var passed []metav1.Condition
+	s.Pass(&passed, 1, "A", "done")
+	if got := find(t, passed, "A").Reason; got != conditions.ReasonReconciled {
+		t.Errorf("passed reason = %q, want %q", got, conditions.ReasonReconciled)
+	}
+
+	var failed []metav1.Condition
+	s.Fail(&failed, 1, "A", errors.New("boom"))
+	if got := find(t, failed, "A").Reason; got != conditions.ReasonReconcileFailed {
+		t.Errorf("failed reason = %q, want %q", got, conditions.ReasonReconcileFailed)
+	}
+	if got := find(t, failed, "B").Reason; got != conditions.ReasonWaitingForDependency {
+		t.Errorf("blocked reason = %q, want %q", got, conditions.ReasonWaitingForDependency)
+	}
+	if conditions.Get(failed, conditions.TypeReady) == nil {
+		t.Errorf("the aggregate must be published as %q, got %v", conditions.TypeReady, types(failed))
+	}
+
+	var waiting []metav1.Condition
+	s.Wait(&waiting, 1, "A", "", "still coming up")
+	if got := find(t, waiting, "A").Reason; got != conditions.ReasonPending {
+		t.Errorf("in-progress reason = %q, want %q", got, conditions.ReasonPending)
+	}
+}
+
+func TestStagesAdvance(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B", "C"}}
+
+	t.Run("a stage that passed lets the reconcile proceed", func(t *testing.T) {
+		var conds []metav1.Condition
+
+		if !s.Advance(&conds, 1, "A", true, "", "done", nil) {
+			t.Fatal("Advance should have reported that the reconcile may proceed")
+		}
+
+		a := find(t, conds, "A")
+		if a.Status != metav1.ConditionTrue || a.Reason != conditions.ReasonReconciled || a.Message != "done" {
+			t.Errorf("A = %+v", a)
+		}
+		if len(conds) != 1 {
+			t.Errorf("a passing stage must not touch anything else, got %v", types(conds))
+		}
+	})
+
+	t.Run("a failed stage blocks the ones after it and the aggregate", func(t *testing.T) {
+		var conds []metav1.Condition
+
+		if s.Advance(&conds, 2, "A", false, "", "", errors.New("the backend is unreachable")) {
+			t.Fatal("Advance should have stopped the reconcile")
+		}
+
+		a := find(t, conds, "A")
+		if a.Status != metav1.ConditionFalse || a.Reason != conditions.ReasonReconcileFailed {
+			t.Errorf("A = %+v", a)
+		}
+		if a.Message != "the backend is unreachable" {
+			t.Errorf("the error text belongs in the message, got %q", a.Message)
+		}
+
+		for _, downstream := range []string{"B", "C"} {
+			c := find(t, conds, downstream)
+			if c.Status != metav1.ConditionFalse || c.Reason != conditions.ReasonWaitingForDependency {
+				t.Errorf("%s = %+v, want False/%s", downstream, c, conditions.ReasonWaitingForDependency)
+			}
+		}
+
+		for _, condType := range []string{"B", "C", conditions.TypeReady} {
+			if got := find(t, conds, condType).ObservedGeneration; got != 2 {
+				t.Errorf("%s must say which generation it describes, got %d", condType, got)
+			}
+		}
+	})
+
+	t.Run("an unfinished stage blocks the same way but keeps its own reason", func(t *testing.T) {
+		var conds []metav1.Condition
+
+		if s.Advance(&conds, 1, "A", false, "Provisioning", "still coming up", nil) {
+			t.Fatal("Advance should have stopped the reconcile")
+		}
+
+		a := find(t, conds, "A")
+		if a.Status != metav1.ConditionFalse || a.Reason != "Provisioning" {
+			t.Errorf("A = %+v, want False/Provisioning", a)
+		}
+		if find(t, conds, "B").Reason != conditions.ReasonWaitingForDependency {
+			t.Error("B should be blocked")
+		}
+	})
+
+	t.Run("an error outranks done", func(t *testing.T) {
+		var conds []metav1.Condition
+
+		if s.Advance(&conds, 1, "A", true, "", "done", errors.New("boom")) {
+			t.Fatal("an error must stop the reconcile whatever done says")
+		}
+		if find(t, conds, "A").Status != metav1.ConditionFalse {
+			t.Error("A should be False")
+		}
+	})
+}
+
+// Advance is the three outcome methods behind one call, and has to stay exactly
+// that: the modules migrating onto this type write it one way and read the other
+// in the docs.
+func TestAdvanceIsPassFailWait(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+	boom := errors.New("boom")
+
+	for _, tc := range []struct {
+		name     string
+		advance  func(conds *[]metav1.Condition) bool
+		explicit func(conds *[]metav1.Condition)
+		proceed  bool
+	}{
+		{
+			name:     "pass",
+			advance:  func(c *[]metav1.Condition) bool { return s.Advance(c, 1, "A", true, "", "done", nil) },
+			explicit: func(c *[]metav1.Condition) { s.Pass(c, 1, "A", "done") },
+			proceed:  true,
+		},
+		{
+			name:     "fail",
+			advance:  func(c *[]metav1.Condition) bool { return s.Advance(c, 1, "A", false, "", "", boom) },
+			explicit: func(c *[]metav1.Condition) { s.Fail(c, 1, "A", boom) },
+		},
+		{
+			name:     "wait",
+			advance:  func(c *[]metav1.Condition) bool { return s.Advance(c, 1, "A", false, "Provisioning", "soon", nil) },
+			explicit: func(c *[]metav1.Condition) { s.Wait(c, 1, "A", "Provisioning", "soon") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var viaAdvance, viaMethod []metav1.Condition
+
+			if got := tc.advance(&viaAdvance); got != tc.proceed {
+				t.Errorf("Advance = %v, want %v", got, tc.proceed)
+			}
+			tc.explicit(&viaMethod)
+
+			if len(viaAdvance) != len(viaMethod) {
+				t.Fatalf("Advance wrote %v, the method wrote %v", types(viaAdvance), types(viaMethod))
+			}
+			for i := range viaAdvance {
+				if !conditions.SemanticallyEqual(&viaAdvance[i], &viaMethod[i]) {
+					t.Errorf("condition %s differs: %+v vs %+v",
+						viaAdvance[i].Type, viaAdvance[i], viaMethod[i])
+				}
+			}
+		})
+	}
+}
+
+// Fail runs inside a reconcile, where taking the controller down over a nil is
+// worse than recording a failure with no detail.
+func TestFailWithoutAnErrorDoesNotPanic(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A"}}
+	var conds []metav1.Condition
+
+	s.Fail(&conds, 1, "A", nil)
+
+	a := find(t, conds, "A")
+	if a.Status != metav1.ConditionFalse || a.Reason != conditions.ReasonReconcileFailed {
+		t.Errorf("A = %+v, want False/%s", a, conditions.ReasonReconcileFailed)
+	}
+	if a.Message == "" {
+		t.Error("a failure with no error should still say something")
+	}
+}
+
+// The stage that was gated on has already said why it did not pass; overwriting
+// it with a blocked reason would lose that.
+func TestGateLeavesTheStageItGatedOnAlone(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+	var conds []metav1.Condition
+
+	s.Gate(&conds, 1, "A")
+
+	if conditions.Get(conds, "A") != nil {
+		t.Error("Gate must not write the stage it gated on")
+	}
+	for _, downstream := range []string{"B", conditions.TypeReady} {
+		if conditions.Get(conds, downstream) == nil {
+			t.Errorf("%s should have been blocked", downstream)
+		}
+	}
+}
+
+// A condition that is not a stage keeps whatever its own publisher last said.
+// sds-elastic relies on this: UpgradeInProgress has to stay True for the whole
+// rolling upgrade, while the stages around it are blocked.
+func TestGateLeavesConditionsOutsideTheStagesAlone(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+	conds := []metav1.Condition{
+		{Type: "UpgradeInProgress", Status: metav1.ConditionTrue, Reason: "Upgrading", Message: "rolling"},
+	}
+
+	s.Gate(&conds, 1, "A")
+
+	signal := find(t, conds, "UpgradeInProgress")
+	if signal.Status != metav1.ConditionTrue || signal.Reason != "Upgrading" {
+		t.Errorf("the signal condition was disturbed: %+v", signal)
+	}
+}
+
+// The aggregate is the condition operators alert on, and a controller returning
+// straight after a failed stage never recomputes it. Handing it the blocked
+// reason would report "waiting for a dependency" for a hard failure whose text
+// is sitting one condition away.
+func TestGateWritesTheAggregateTheReadyConditionWouldGive(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+	var conds []metav1.Condition
+
+	s.Fail(&conds, 1, "A", errors.New("the backend is unreachable"))
+
+	ready := find(t, conds, conditions.TypeReady)
+	if ready.Status != metav1.ConditionFalse || ready.Reason != conditions.ReasonReconcileFailed {
+		t.Errorf("Ready = %+v, want False/%s", ready, conditions.ReasonReconcileFailed)
+	}
+	if !strings.Contains(ready.Message, "the backend is unreachable") {
+		t.Errorf("the aggregate must carry the failure, got %q", ready.Message)
+	}
+	if want := s.ReadyCondition(conds, 1); !conditions.SemanticallyEqual(&ready, &want) {
+		t.Errorf("Gate wrote %+v, ReadyCondition gives %+v", ready, want)
+	}
+}
+
+// A stage name that is not in Types is a typo Validate exists to catch. Until it
+// is caught, the stage conditions know nothing about the failure that got here —
+// and reporting the resource as ready would be the worst of the readings.
+func TestGateOnAnUnknownStageDoesNotReportReady(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+	var conds []metav1.Condition
+	s.Pass(&conds, 1, "A", "done")
+	s.Pass(&conds, 1, "B", "done")
+
+	s.Gate(&conds, 1, "Typo")
+
+	ready := find(t, conds, conditions.TypeReady)
+	if ready.Status != metav1.ConditionFalse || ready.Reason != conditions.ReasonWaitingForDependency {
+		t.Errorf("Ready = %+v, want False/%s", ready, conditions.ReasonWaitingForDependency)
+	}
+}
+
+// A module with a vocabulary of its own has to be able to keep it, or moving
+// onto this type would silently rewrite the machine-readable strings its
+// dashboards and alerts are keyed on.
+func TestStagesHonoursACallersVocabulary(t *testing.T) {
+	s := conditions.Stages{
+		Types:      []string{"A", "B"},
+		Passed:     "Ready",
+		Failed:     "Error",
+		InProgress: "InProgress",
+		Blocked:    "WaitingForPrev",
+	}
+
+	var conds []metav1.Condition
+	s.Fail(&conds, 1, "A", errors.New("boom"))
+
+	if got := find(t, conds, "A").Reason; got != "Error" {
+		t.Errorf("failed reason = %q, want Error", got)
+	}
+	if got := find(t, conds, "B").Reason; got != "WaitingForPrev" {
+		t.Errorf("blocked reason = %q, want WaitingForPrev", got)
+	}
+	if got := find(t, conds, conditions.TypeReady).Reason; got != "Error" {
+		t.Errorf("aggregate reason = %q, want Error", got)
+	}
+
+	var ok []metav1.Condition
+	s.Pass(&ok, 1, "A", "done")
+	if got := find(t, ok, "A").Reason; got != "Ready" {
+		t.Errorf("passed reason = %q, want Ready", got)
+	}
+}
+
+// ReadyType is read on two paths — Gate and ReadyCondition — and a module whose
+// aggregate is not called "Ready" has to get both. Writing this package's
+// TypeReady alongside the caller's would leave a second, permanently stale
+// aggregate on the resource.
+func TestStagesHonoursACallersReadyType(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}, ReadyType: "Available"}
+
+	var conds []metav1.Condition
+	s.Fail(&conds, 1, "A", errors.New("boom"))
+
+	if conditions.Get(conds, conditions.TypeReady) != nil {
+		t.Errorf("only the caller's aggregate may be written, got %v", types(conds))
+	}
+	if got := find(t, conds, "Available").Status; got != metav1.ConditionFalse {
+		t.Errorf("Available = %q, want False", got)
+	}
+
+	if got := s.ReadyCondition(conds, 1).Type; got != "Available" {
+		t.Errorf("ReadyCondition type = %q, want Available", got)
+	}
+
+	var clean []metav1.Condition
+	s.Pass(&clean, 1, "A", "done")
+	s.Pass(&clean, 1, "B", "done")
+	s.SetReady(&clean, 1, "all stages reconciled")
+	if got := find(t, clean, "Available").Status; got != metav1.ConditionTrue {
+		t.Errorf("Available = %q, want True", got)
+	}
+}
+
+// Phase reads the caller's failure reason, not this package's, or a module with
+// its own vocabulary would never see PhaseError.
+func TestPhaseReadsTheCallersFailureReason(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A"}, Failed: "Error", InProgress: "InProgress"}
+	conds := []metav1.Condition{{Type: "A", Status: metav1.ConditionFalse, Reason: "Error"}}
+
+	if got := s.Phase(conds); got != conditions.PhaseError {
+		t.Errorf("Phase = %q, want %q", got, conditions.PhaseError)
+	}
+
+	conds = []metav1.Condition{{Type: "A", Status: metav1.ConditionFalse, Reason: "InProgress"}}
+	if got := s.Phase(conds); got != conditions.PhaseInProgress {
+		t.Errorf("Phase = %q, want %q", got, conditions.PhaseInProgress)
+	}
+}
+
+func TestSkipMissing(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}, SkipMissing: true}
+	strict := conditions.Stages{Types: []string{"A", "B"}}
+
+	t.Run("a missing stage is not evidence of a problem", func(t *testing.T) {
+		conds := []metav1.Condition{{Type: "A", Status: metav1.ConditionTrue}}
+
+		if got := s.Aggregate(conds); got != metav1.ConditionTrue {
+			t.Errorf("Aggregate = %q, want True", got)
+		}
+		if got := strict.Aggregate(conds); got != metav1.ConditionUnknown {
+			t.Errorf("without SkipMissing, Aggregate = %q, want Unknown", got)
+		}
+	})
+
+	// Skipping every stage would report a brand-new resource as ready, which is
+	// the one case where the option must not apply.
+	t.Run("no stage with a verdict at all is still Unknown", func(t *testing.T) {
+		if got := s.Aggregate(nil); got != metav1.ConditionUnknown {
+			t.Errorf("Aggregate = %q, want Unknown", got)
+		}
+		if got := s.Phase(nil); got != conditions.PhasePending {
+			t.Errorf("Phase = %q, want %q", got, conditions.PhasePending)
+		}
+	})
+
+	// A stage that is present and Unknown says the controller looked and could
+	// not tell, which is evidence — unlike the absence of a condition.
+	t.Run("a stage present and Unknown is not skipped", func(t *testing.T) {
+		conds := []metav1.Condition{
+			{Type: "A", Status: metav1.ConditionTrue},
+			{Type: "B", Status: metav1.ConditionUnknown},
+		}
+
+		if got := s.Aggregate(conds); got != metav1.ConditionUnknown {
+			t.Errorf("Aggregate = %q, want Unknown", got)
+		}
+	})
+
+	t.Run("a missing stage does not become the aggregate's message", func(t *testing.T) {
+		conds := []metav1.Condition{
+			{Type: "A", Status: metav1.ConditionFalse, Reason: "Error", Message: "backend down"},
+		}
+		s := conditions.Stages{Types: []string{"A", "B"}, SkipMissing: true, Failed: "Error"}
+
+		got := s.ReadyCondition(conds, 1)
+		if !strings.Contains(got.Message, "backend down") {
+			t.Errorf("the aggregate should name the stage that failed, got %q", got.Message)
+		}
+	})
+}
+
+// The success write is the third part of the machine, and the part every module
+// had been doing by hand. Without it a controller that walked every stage leaves
+// the aggregate saying whatever the last failure said.
+func TestSetReady(t *testing.T) {
+	t.Run("a clean pass says what it achieved", func(t *testing.T) {
+		s := conditions.Stages{Types: []string{"A"}}
+		var conds []metav1.Condition
+		s.Pass(&conds, 3, "A", "done")
+
+		if !s.SetReady(&conds, 3, "the backend is in place") {
+			t.Fatal("SetReady should have reported the write")
+		}
+
+		ready := find(t, conds, conditions.TypeReady)
+		if ready.Status != metav1.ConditionTrue ||
+			ready.Reason != conditions.ReasonReconciled ||
+			ready.ObservedGeneration != 3 ||
+			ready.Message != "the backend is in place" {
+			t.Errorf("Ready = %+v", ready)
+		}
+	})
+
+	// This is the failure the method exists to prevent: a resource that failed,
+	// then converged, must not keep reporting the failure on its aggregate.
+	t.Run("it clears an aggregate left over from a failed pass", func(t *testing.T) {
+		s := conditions.Stages{Types: []string{"A"}}
+		var conds []metav1.Condition
+
+		s.Fail(&conds, 1, "A", errors.New("the backend is unreachable"))
+		if find(t, conds, conditions.TypeReady).Status != metav1.ConditionFalse {
+			t.Fatal("the aggregate should be False after a failure")
+		}
+
+		s.Pass(&conds, 2, "A", "done")
+		s.SetReady(&conds, 2, "all stages reconciled")
+
+		ready := find(t, conds, conditions.TypeReady)
+		if ready.Status != metav1.ConditionTrue || ready.ObservedGeneration != 2 {
+			t.Errorf("Ready = %+v, want True at generation 2", ready)
+		}
+	})
+
+	// Below True the message naming the stage that is not passing is the one an
+	// operator needs; what the pass managed before that is not.
+	t.Run("a pass that did not converge keeps the stage's message", func(t *testing.T) {
+		s := conditions.Stages{Types: []string{"A", "B"}}
+		var conds []metav1.Condition
+		s.Pass(&conds, 1, "A", "done")
+		s.Wait(&conds, 1, "B", "", "not published yet")
+
+		s.SetReady(&conds, 1, "the backend is in place")
+
+		ready := find(t, conds, conditions.TypeReady)
+		if ready.Status != metav1.ConditionFalse {
+			t.Fatalf("Ready = %q, want False", ready.Status)
+		}
+		if !strings.Contains(ready.Message, "not published yet") {
+			t.Errorf("the aggregate should name the stage that is not passing, got %q", ready.Message)
+		}
+		if strings.Contains(ready.Message, "the backend is in place") {
+			t.Errorf("the success message must be dropped below True, got %q", ready.Message)
+		}
+	})
+
+	t.Run("it truncates a long success message", func(t *testing.T) {
+		s := conditions.Stages{Types: []string{"A"}}
+		var conds []metav1.Condition
+		s.Pass(&conds, 1, "A", "done")
+
+		s.SetReady(&conds, 1, strings.Repeat("x", conditions.MaxMessageLen*2))
+
+		if n := len([]rune(find(t, conds, conditions.TypeReady).Message)); n > conditions.MaxMessageLen {
+			t.Errorf("message = %d runes, want at most %d", n, conditions.MaxMessageLen)
+		}
+	})
+}
+
+// A stage name is a plain string on every method that takes one, so the typo
+// that would otherwise surface only as a resource stuck reporting Unknown has to
+// be catchable where the value is built.
+func TestValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		stages  conditions.Stages
+		wantErr bool
+	}{
+		{"a usable set", conditions.Stages{Types: []string{"A", "B"}}, false},
+		{"a caller's own aggregate", conditions.Stages{Types: []string{"A"}, ReadyType: "Available"}, false},
+		{"no stages", conditions.Stages{}, true},
+		{"an empty stage type", conditions.Stages{Types: []string{"A", ""}}, true},
+		{"a stage listed twice", conditions.Stages{Types: []string{"A", "B", "A"}}, true},
+		{"the aggregate is also a stage", conditions.Stages{Types: []string{"A", "Ready"}}, true},
+		{
+			"the caller's aggregate is also a stage",
+			conditions.Stages{Types: []string{"A", "Available"}, ReadyType: "Available"},
+			true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.stages.Validate()
+			if tc.wantErr && err == nil {
+				t.Error("expected an error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestKnown(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+
+	if !s.Known("B") {
+		t.Error("B is a stage")
+	}
+	if s.Known("Typo") {
+		t.Error("Typo is not a stage")
+	}
+	if s.Known(conditions.TypeReady) {
+		t.Error("the aggregate is not a stage")
+	}
+}
+
+// Reproduces what sds-object and sds-elastic do today, so that moving them onto
+// this type can be reviewed as a move rather than as a change of behaviour.
+func TestReproducesTheModuleStateMachines(t *testing.T) {
+	s := conditions.Stages{
+		Types:       []string{"BackendReady", "EndpointReady"},
+		Passed:      "Ready",
+		Failed:      "Error",
+		InProgress:  "InProgress",
+		Blocked:     "WaitingForPrev",
+		SkipMissing: true,
+	}
+
+	if err := s.Validate(); err != nil {
+		t.Fatalf("the module's stage set should be usable: %v", err)
+	}
+
+	t.Run("every stage passes", func(t *testing.T) {
+		var conds []metav1.Condition
+		for _, stage := range s.Types {
+			if !s.Advance(&conds, 1, stage, true, "", "done", nil) {
+				t.Fatalf("stage %s should have passed", stage)
+			}
+		}
+		s.SetReady(&conds, 1, "All stages reconciled")
+
+		if got := s.Phase(conds); got != conditions.PhaseReady {
+			t.Errorf("Phase = %q, want %q", got, conditions.PhaseReady)
+		}
+		ready := find(t, conds, conditions.TypeReady)
+		if ready.Status != metav1.ConditionTrue || ready.Message != "All stages reconciled" {
+			t.Errorf("Ready = %+v", ready)
+		}
+	})
+
+	t.Run("the first stage fails", func(t *testing.T) {
+		var conds []metav1.Condition
+		s.Advance(&conds, 1, "BackendReady", false, "", "", errors.New("unreachable"))
+
+		if got := s.Phase(conds); got != conditions.PhaseError {
+			t.Errorf("Phase = %q, want %q", got, conditions.PhaseError)
+		}
+		if got := find(t, conds, "EndpointReady").Reason; got != "WaitingForPrev" {
+			t.Errorf("EndpointReady reason = %q, want WaitingForPrev", got)
+		}
+		if got := find(t, conds, "Ready").Status; got != metav1.ConditionFalse {
+			t.Errorf("the aggregate = %q, want False", got)
+		}
+	})
+
+	t.Run("a stage is in progress", func(t *testing.T) {
+		var conds []metav1.Condition
+		s.Advance(&conds, 1, "BackendReady", true, "", "done", nil)
+		s.Advance(&conds, 1, "EndpointReady", false, "", "not published yet", nil)
+
+		if got := s.Phase(conds); got != conditions.PhaseInProgress {
+			t.Errorf("Phase = %q, want %q", got, conditions.PhaseInProgress)
+		}
+	})
+}
+
+// Advance and Gate go through Set, so a stage written twice in one pass leaves
+// one condition rather than a duplicate the API server would reject.
+func TestAdvanceDoesNotDuplicateAStage(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A", "B"}}
+	var conds []metav1.Condition
+
+	s.Advance(&conds, 1, "A", false, "", "", errors.New("first"))
+	s.Advance(&conds, 1, "A", true, "", "second", nil)
+
+	count := 0
+	for _, c := range conds {
+		if c.Type == "A" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("A appears %d times, want 1", count)
+	}
+	if got := find(t, conds, "A").Message; got != "second" {
+		t.Errorf("the later write should win, got %q", got)
+	}
+}
+
+// An error from a failing backend can be arbitrarily long, and the CRD caps the
+// message.
+func TestAdvanceTruncatesALongMessage(t *testing.T) {
+	s := conditions.Stages{Types: []string{"A"}}
+	var conds []metav1.Condition
+
+	s.Advance(&conds, 1, "A", false, "", "", errors.New(strings.Repeat("x", conditions.MaxMessageLen+100)))
+
+	for _, condType := range []string{"A", conditions.TypeReady} {
+		if got := len([]rune(find(t, conds, condType).Message)); got > conditions.MaxMessageLen {
+			t.Errorf("%s message = %d runes, want at most %d", condType, got, conditions.MaxMessageLen)
+		}
+	}
+}

--- a/conditions/update.go
+++ b/conditions/update.go
@@ -40,13 +40,59 @@ func UpdateStatus[T client.Object](
 ) error {
 	key := client.ObjectKeyFromObject(obj)
 
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	read := func(ctx context.Context) (T, error) {
 		fresh, ok := obj.DeepCopyObject().(T)
 		if !ok {
-			return fmt.Errorf("deep copy of %T did not yield the same type", obj)
+			var zero T
+			return zero, fmt.Errorf("deep copy of %T did not yield the same type", obj)
 		}
 		if err := cl.Get(ctx, key, fresh); err != nil {
+			var zero T
+			return zero, err
+		}
+		return fresh, nil
+	}
+
+	write := func(ctx context.Context, fresh T) error {
+		return cl.Status().Update(ctx, fresh)
+	}
+
+	return UpdateStatusVia(ctx, read, write, mutate)
+}
+
+// UpdateStatusVia is [UpdateStatus] for callers that do not hold a
+// client.Client.
+//
+// Some of the modules reach Kubernetes through a repository they define and mock
+// in tests — the object never travels as a client.Object through their
+// controllers, and the method that writes its status is named after the kind.
+// Handing the read and the write in as functions lets those callers have the
+// retry, the fresh state and the skipped no-op write without giving up the
+// layering, which was the only thing keeping them on hand-rolled update loops.
+//
+// read must return state read from the API server, not a cached copy: it is
+// called again on every retry, and re-mutating a stale object is what the retry
+// exists to avoid. It must also return a non-nil object whenever it returns a
+// nil error — reporting an absent object as (nil, nil) is a common enough
+// repository idiom that the nil is checked here rather than dereferenced.
+// write persists the status subresource of what it is given.
+//
+// mutate must be free of side effects outside the object, since it can run more
+// than once, and must cope with a nil status pointer.
+func UpdateStatusVia[T client.Object](
+	ctx context.Context,
+	read func(context.Context) (T, error),
+	write func(context.Context, T) error,
+	mutate func(T),
+) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh, err := read(ctx)
+		if err != nil {
 			return err
+		}
+		var zero T
+		if any(fresh) == any(zero) {
+			return fmt.Errorf("read returned a nil %T without an error", fresh)
 		}
 
 		before, ok := fresh.DeepCopyObject().(T)
@@ -60,6 +106,6 @@ func UpdateStatus[T client.Object](
 			return nil
 		}
 
-		return cl.Status().Update(ctx, fresh)
+		return write(ctx, fresh)
 	})
 }

--- a/conditions/update_test.go
+++ b/conditions/update_test.go
@@ -2,6 +2,8 @@ package conditions_test
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -171,5 +173,146 @@ func TestUpdateStatus_PropagatesGetError(t *testing.T) {
 	})
 	if !apierrors.IsNotFound(err) {
 		t.Fatalf("expected a NotFound error, got %v", err)
+	}
+}
+
+// UpdateStatusVia exists for the modules that reach Kubernetes through a
+// repository of their own. The pair of functions stands in for the client, and
+// everything UpdateStatus gives has to survive the substitution.
+func TestUpdateStatusVia_WritesMutation(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+	ctx := context.Background()
+
+	read := func(ctx context.Context) (*corev1.Pod, error) {
+		got := &corev1.Pod{}
+		err := cl.Get(ctx, client.ObjectKeyFromObject(pod), got)
+		return got, err
+	}
+	write := func(ctx context.Context, p *corev1.Pod) error { return cl.Status().Update(ctx, p) }
+
+	err := conditions.UpdateStatusVia(ctx, read, write, func(p *corev1.Pod) {
+		p.Status.Message = "written through a repository"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatusVia: %v", err)
+	}
+
+	if got := readPod(t, cl).Status.Message; got != "written through a repository" {
+		t.Fatalf("expected the mutation to be persisted, got %q", got)
+	}
+}
+
+func TestUpdateStatusVia_SkipsNoOpWrite(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+	ctx := context.Background()
+
+	writes := 0
+	read := func(ctx context.Context) (*corev1.Pod, error) {
+		got := &corev1.Pod{}
+		err := cl.Get(ctx, client.ObjectKeyFromObject(pod), got)
+		return got, err
+	}
+	write := func(ctx context.Context, p *corev1.Pod) error {
+		writes++
+		return cl.Status().Update(ctx, p)
+	}
+
+	if err := conditions.UpdateStatusVia(ctx, read, write, func(*corev1.Pod) {}); err != nil {
+		t.Fatalf("UpdateStatusVia: %v", err)
+	}
+
+	if writes != 0 {
+		t.Fatalf("a mutation that changes nothing must not write, got %d writes", writes)
+	}
+}
+
+// The retry is the reason to use this at all, and it is only worth anything if
+// the second attempt mutates state read again rather than the state that lost.
+func TestUpdateStatusVia_RetriesAgainstFreshlyReadState(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+	ctx := context.Background()
+
+	reads := 0
+	read := func(ctx context.Context) (*corev1.Pod, error) {
+		reads++
+		got := &corev1.Pod{}
+		err := cl.Get(ctx, client.ObjectKeyFromObject(pod), got)
+		return got, err
+	}
+
+	writes := 0
+	write := func(ctx context.Context, p *corev1.Pod) error {
+		writes++
+		if writes == 1 {
+			return apierrors.NewConflict(
+				schema.GroupResource{Resource: "pods"}, p.Name, errors.New("stale"))
+		}
+		return cl.Status().Update(ctx, p)
+	}
+
+	err := conditions.UpdateStatusVia(ctx, read, write, func(p *corev1.Pod) {
+		p.Status.Message = "written on the retry"
+	})
+	if err != nil {
+		t.Fatalf("UpdateStatusVia: %v", err)
+	}
+
+	if reads < 2 {
+		t.Errorf("the retry must read again, got %d reads", reads)
+	}
+	if got := readPod(t, cl).Status.Message; got != "written on the retry" {
+		t.Errorf("expected the retry to persist the mutation, got %q", got)
+	}
+}
+
+func TestUpdateStatusVia_PropagatesReadError(t *testing.T) {
+	want := errors.New("the repository is unreachable")
+
+	err := conditions.UpdateStatusVia(context.Background(),
+		func(context.Context) (*corev1.Pod, error) { return nil, want },
+		func(context.Context, *corev1.Pod) error { t.Fatal("write must not be reached"); return nil },
+		func(*corev1.Pod) {})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+func TestUpdateStatusVia_PropagatesWriteError(t *testing.T) {
+	pod := newPod()
+	cl := newClient(t, pod)
+	want := errors.New("the repository refused the write")
+
+	err := conditions.UpdateStatusVia(context.Background(),
+		func(ctx context.Context) (*corev1.Pod, error) {
+			got := &corev1.Pod{}
+			e := cl.Get(ctx, client.ObjectKeyFromObject(pod), got)
+			return got, e
+		},
+		func(context.Context, *corev1.Pod) error { return want },
+		func(p *corev1.Pod) { p.Status.Message = "changed" })
+
+	if !errors.Is(err, want) {
+		t.Fatalf("got %v, want %v", err, want)
+	}
+}
+
+// Reporting an absent object as (nil, nil) is a common repository idiom, and the
+// caller this exists for is exactly a repository. Diagnosing it as a failure to
+// deep-copy would send the reader looking in the wrong place.
+func TestUpdateStatusVia_RejectsANilReadWithoutAnError(t *testing.T) {
+	err := conditions.UpdateStatusVia(context.Background(),
+		func(context.Context) (*corev1.Pod, error) { return nil, nil },
+		func(context.Context, *corev1.Pod) error { t.Fatal("write must not be reached"); return nil },
+		func(*corev1.Pod) { t.Fatal("mutate must not be reached") })
+
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("the error should name the nil it got, got %q", err)
 	}
 }


### PR DESCRIPTION
## Description

Three gaps in `conditions`: two found while reviewing csi-netapp's conditions work, one while working through what the modules still writing conditions by hand actually need.

### 1. A successful pass has no way to say what it achieved

`Ready` takes only the error, so the message is empty on success and `kubectl describe` shows a Ready condition with nothing next to it. Every consumer works around this the same way — csi-ceph does it at both of its call sites:

```go
cond := conditions.Ready(generation, reconcileErr)
if cond.Message == "" {
    cond.Message = msg
}
```

`ReadyWithMessage(generation, msg, err)` takes that message directly, with the same semantics the workaround has: `msg` on success, error text on failure.

The message is carried rather than derived from the kind because a pass can succeed without having done everything the kind eventually does — an optional CRD is not registered in the cluster, the resource it would have decorated does not exist yet. A fixed `"has been reconciled"` would state something the controller does not know to be true. An empty `msg` is left empty for the same reason; a caller that does want a fallback supplies it and keeps the choice visible at its own call site.

### 2. No message is bounded

`condition.message` is capped at 32768 characters by `metav1.Condition`, and the cap is enforced over the *whole* status update: one message over it is rejected as a unit, so the resource keeps the conditions it had before or, on a first pass, gets none at all. That last state is exactly what an absent condition cannot be distinguished from — "never evaluated" — so an over-long error turns a diagnosis into silence. A controller whose message is an error text it did not produce cannot bound it.

Everything this package builds now truncates. `MaxMessageLen` and `TruncateMessage` are exported for modules shaping conditions of their own, so the constant is not re-derived per module and left to drift from the schema. The cut is made over runes, not bytes: the apiserver counts characters, and cutting on bytes would both overshoot and be able to split a rune into invalid UTF-8.

### 3. Four modules are still writing conditions by hand

In each case something specific was in the way rather than inertia. This adds what they need, without changing anything for the eight already on the package.

**Writing through a repository.** csi-scsi-generic and csi-netapp reach Kubernetes through a repository they define and mock in tests: the object never travels as a `client.Object` through their controllers, and the method that writes its status is named after the kind. `UpdateStatus` wanted a `client.Client`, so both kept hand-rolled update loops. `UpdateStatusVia` takes the read and the write as functions instead, and `UpdateStatus` is now a thin wrapper over it — same behaviour, one implementation.

**A state machine two modules had grown separately.** sds-object and sds-elastic each walk an ordered set of stage conditions, mark everything downstream as blocked when one does not pass, and fold the lot into an aggregate. The copies had already drifted. `Stages` carries that machine — `Pass`/`Fail`/`Wait` (and `Advance` behind them), `Gate`, `Aggregate`, `ReadyCondition`, `SetReady`, `Phase` — and only the condition handling: the status builders those modules flush through are full of their own fields and stay where they are.

Two things stopped them from using what was already here, and `Stages` makes both explicit rather than assumed:

- **the reason vocabulary.** `Aggregate` and `DerivePhase` hardcoded this package's reasons, so a module reporting `Error`/`InProgress`/`WaitingForPrev` would have been given a phase computed from strings it never writes. The zero value is still this package's vocabulary, so a caller that fills only `Types` gets what the package-level functions give.
- **what a missing stage means.** Here it counts as Unknown, because a stage that has never been evaluated is not evidence that the resource is healthy; both modules skip it and report Ready. `SkipMissing` lets them move across without changing what their users see, and tighten it afterwards as a change of its own. Even with it set, a resource where no stage has a verdict at all aggregates to Unknown rather than Ready. It covers a *missing* stage only — a stage present and Unknown says the controller looked and could not tell, which is evidence.

**The whole machine, not two thirds of it.** `Advance` and `Gate` write the aggregate only on the paths where a stage did not pass. The success write — `"All stages reconciled"` in [sds-object's `object_store_controller.go`](https://fox.flant.com/deckhouse/storage/sds-object/-/blob/main/images/controller/internal/controller/object_store_controller.go#L199) — is the third part, and leaving it out would mean a controller that walked every stage keeps whatever the last failure said on the aggregate: False, forever, on a resource that converged. `SetReady` is that write, and it takes the message, so the module does not keep its own copy of that either.

**One aggregate, one answer.** `Gate` used to give the aggregate the blocked reason directly, which is what both modules do today: a hard failure came out as `WaitingForDependency` / `"waiting for StorageReady"` while the error text sat one condition away — and on the path a controller actually takes, `if !s.Advance(...) { return }`, nothing recomputes it afterwards. It now goes through `ReadyCondition`, so `Ready` says the same thing whichever path reached it. **This is the one place the port is deliberately not what the modules do today**, and the one thing to review as a behaviour decision rather than as a move.

**Three outcomes, three names.** `Pass`, `Fail` and `Wait` are the outcome methods; `Advance` is the three behind one call, kept because the modules' loops are already shaped around a computed `done`. New code reads better with the three: the outcome is in the name of the method rather than in a bare `true`/`false` several arguments in, and a `reason` cannot be handed to a path that ignores it.

**Typos in stage names.** A stage name is a plain string on every method that takes one, and a name that is not in `Types` produces a condition `Aggregate` never reads — the resource then reports Unknown forever with no other symptom to go on. `Validate` and `Known` make that catchable where the `Stages` value is built.

`Gate` deliberately leaves alone any condition that is not a stage: sds-elastic's `UpgradeInProgress` has to keep its value for the whole rolling upgrade while the stages around it are blocked, which its own `gateAfter` documents at length.

Not added: a helper that sets the condition and `status.observedGeneration` together. `observedGeneration` lives on each module's own status struct, which this package cannot reach without every consumer implementing an interface for it — more ceremony than the two lines it would save.

## Why do we need it, and what problem does it solve?

`conditions.Ready` is the one-liner behind the single-stage controllers, and both of its gaps are visible to operators:

- an empty message means the only place a controller can explain a healthy-but-partial pass is a log line nobody correlates with the resource;
- an unbounded message means the failure an operator most needs to read — a long error from a storage backend — is the one that gets the status update rejected, leaving `status.conditions` empty and the reconcile loop requeueing with no in-cluster trace.

csi-netapp solved both locally ([csi-netapp!111](https://fox.flant.com/deckhouse/storage/csi-netapp/-/merge_requests/111)) and cannot delete its copy until they exist here. csi-ceph, csi-nfs and sds-local-volume have the truncation bug today.

The four modules off the package are the other half: every one of them is a second copy of code whose first copy is already here, and the sds-object / sds-elastic copies had drifted apart before either was a year old.

## What is the expected result?

- `ReadyWithMessage` available; `Ready` unchanged for existing callers.
- No condition this package builds can exceed `MaxMessageLen`.
- Modules can drop their local `Ready`-plus-set-message idiom, their own copies of the limit, their hand-rolled status-update loops, and their own stage machines.

**Backward compatibility.** `Ready` keeps its signature *and* its output — a successful pass still gets an empty message. The tempting move once the field is threaded through is to give it a default, which would silently rewrite the status of every released caller; instead it delegates to `ReadyWithMessage` with an empty message, and `TestReadyLeavesASuccessMessageEmpty` pins that. Truncation is the only behaviour change to a released function, and only above the cap, where the apiserver rejected the update anyway.

Verified against the three modules already released on `v0.7.0`, with this branch `replace`d in:

| Module | Result |
|---|---|
| csi-ceph (`images/controller`) | `go build` + `go test ./...` pass |
| csi-nfs (`images/controller`, `-tags ce`) | `go build` + `go test ./...` pass |
| sds-local-volume (`images/controller`) | `go build` + `go test ./...` pass |

The pre-existing `TestReady`, `TestAggregate`, `TestAggregateReady` and `TestDerivePhase` pass unmodified.

## Checklist

- [x] The code is covered by unit tests — message handling, truncation at/over the limit, rune-not-byte cutting, the `Ready` compatibility guard, `AggregateReady` truncation, `UpdateStatusVia` (write / no-op skip / retry against freshly-read state / read and write errors / nil read), and `Stages` (vocabulary defaults and overrides including a caller's own `ReadyType`, `Pass`/`Fail`/`Wait` equivalence with `Advance`, gating, the aggregate `Gate` writes, `SetReady`, `SkipMissing`, `Validate`, `Known`, and a reproduction of the sds-object / sds-elastic machines).
- [ ] e2e tests passed — n/a: this repository is a library, it has no e2e suite. The consumer check above stands in for it.
- [x] Documentation updated according to the changes — the godoc on every new exported symbol, including why each decision went the way it did.
- [ ] Changes were tested in the Kubernetes cluster manually — not applicable on its own; the behaviour is exercised through the three consumers' test suites.
- [ ] Needs a tag (`v0.8.0`) before modules can adopt it.
